### PR TITLE
GH-61 Refactor configuration class by correcting texts and sorting fields

### DIFF
--- a/src/main/java/com/eternalcode/combat/CombatCommand.java
+++ b/src/main/java/com/eternalcode/combat/CombatCommand.java
@@ -9,7 +9,6 @@ import dev.rollczi.litecommands.command.async.Async;
 import dev.rollczi.litecommands.command.execute.Execute;
 import dev.rollczi.litecommands.command.permission.Permission;
 import dev.rollczi.litecommands.command.route.Route;
-import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import panda.utilities.text.Formatter;
 
@@ -41,8 +40,8 @@ public class CombatCommand {
             .register("{PLAYER}", target.getName());
 
         this.announcer.sendMessage(player, this.fightManager.isInCombat(targetUniqueId)
-            ? formatter.format(messages.inCombat)
-            : formatter.format(messages.notInCombat));
+            ? formatter.format(messages.admin.playerInCombat)
+            : formatter.format(messages.admin.adminPlayerNotInCombat));
     }
 
     @Execute(route = "tag", required = 1)
@@ -56,7 +55,7 @@ public class CombatCommand {
 
         this.fightManager.tag(targetUniqueId, time);
 
-        String format = formatter.format(this.config.messages.adminTagPlayer);
+        String format = formatter.format(this.config.messages.admin.adminTagPlayer);
         this.announcer.sendMessage(player, format);
     }
 
@@ -71,7 +70,7 @@ public class CombatCommand {
         UUID playerUniqueId = player.getUniqueId();
 
         if (playerUniqueId.equals(firstTargetUniqueId) || playerUniqueId.equals(secondTargetUniqueId)) {
-            this.announcer.sendMessage(player, messages.cantTagSelf);
+            this.announcer.sendMessage(player, messages.admin.adminCantTagSelf);
             return;
         }
 
@@ -82,7 +81,7 @@ public class CombatCommand {
             .register("{FIRST_PLAYER}", firstTarget.getName())
             .register("{SECOND_PLAYER}", secondTarget.getName());
 
-        String format = formatter.format(messages.adminTagPlayerMultiple);
+        String format = formatter.format(messages.admin.adminTagPlayerMultiple);
         this.announcer.sendMessage(player, format);
 
         this.announcer.sendMessage(firstTarget, messages.tagPlayer);
@@ -95,7 +94,7 @@ public class CombatCommand {
         UUID targetUniqueId = target.getUniqueId();
 
         if (!this.fightManager.isInCombat(targetUniqueId)) {
-            this.announcer.sendMessage(player, this.config.messages.playerIsNoInCombat);
+            this.announcer.sendMessage(player, this.config.messages.admin.adminPlayerIsNoInCombat);
             return;
         }
 
@@ -105,7 +104,7 @@ public class CombatCommand {
         Formatter formatter = new Formatter()
             .register("{PLAYER}", target.getName());
 
-        String format = formatter.format(this.config.messages.adminUnTagPlayer);
+        String format = formatter.format(this.config.messages.admin.adminUnTagPlayer);
 
         this.announcer.sendMessage(player, format);
     }
@@ -115,6 +114,6 @@ public class CombatCommand {
     @Permission("eternalcombat.reload")
     void execute(Player player) {
         this.configManager.reload();
-        this.announcer.sendMessage(player, this.config.messages.reload);
+        this.announcer.sendMessage(player, this.config.messages.admin.reload);
     }
 }

--- a/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -55,7 +55,7 @@ public final class CombatPlugin extends JavaPlugin {
         NotificationAnnouncer notificationAnnouncer = new NotificationAnnouncer(this.audienceProvider, miniMessage);
         this.liteCommands = LiteBukkitAdventurePlatformFactory.builder(server, "eternalcombat", this.audienceProvider)
             .argument(Player.class, new BukkitPlayerArgument<>(this.getServer(), pluginConfig.messages.cantFindPlayer))
-            .contextualBind(Player.class, new BukkitOnlyPlayerContextual<>(pluginConfig.messages.onlyForPlayers))
+            .contextualBind(Player.class, new BukkitOnlyPlayerContextual<>(pluginConfig.messages.admin.onlyForPlayers))
 
             .invalidUsageHandler(new InvalidUsage(pluginConfig, notificationAnnouncer))
             .permissionHandler(new PermissionMessage(pluginConfig, notificationAnnouncer))

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -15,11 +15,11 @@ import java.util.List;
 
 public class PluginConfig implements ReloadableConfig {
 
-    @Description("# Do you want to change the plugin messages?")
-    public Messages messages = new Messages();
-
-    @Description({ " ", "# Do you want to change the plugin settings?" })
+    @Description("# Do you want to change the plugin settings?")
     public Settings settings = new Settings();
+
+    @Description({ " ", "# Do you want to change the plugin messages?" })
+    public Messages messages = new Messages();
 
     @Override
     public Resource resource(File folder) {
@@ -28,36 +28,39 @@ public class PluginConfig implements ReloadableConfig {
 
     @Contextual
     public static class Settings {
+
         @Description("# Whether the player after entering the server should receive information about the new version of the plugin?")
         public boolean receiveUpdates = true;
 
-        @Description({ " ", "# The length of time the combat is to last" })
+        @Description("# The length of time the combat is to last")
         public Duration combatLogTime = Duration.ofSeconds(20);
 
-        @Description({ " ", "# Combat log notification type, available types: ACTION_BAR, CHAT, TITLE, SUBTITLE" })
+        @Description("# Combat log notification type, available types: ACTION_BAR, CHAT, TITLE, SUBTITLE")
         public NotificationType combatNotificationType = NotificationType.ACTION_BAR;
 
-        @Description({ " ", "# Blocked commands that the player will not be able to use during combat" })
+        @Description("# Blocked commands that the player will not be able to use during combat")
         public List<String> blockedCommands = new ImmutableList.Builder<String>()
             .add("gamemode")
             .add("tp")
             .build();
 
-        @Description({ " ", "# Block the opening of inventory?" })
+        @Description("# Block the opening of inventory?")
         public boolean blockingInventories = true;
 
-        @Description({ " ", "# Whether to block the placement of blocks?" })
+        @Description("# Whether to block the placement of blocks?")
         public boolean blockPlace = true;
 
-        @Description({ " ", "# From which level should place blocks be blocked?" })
+        @Description("# From which level should place blocks be blocked?")
         public int blockPlaceLevel = 40;
 
-        @Description({ " ", "# Should the option below be enabled?" })
+        @Description("# Should the option below be enabled?")
         public boolean enableDamageCauses = true;
 
-        @Description({ " ", "# After what type of damage the player should get a combat log?",
-        "# You can find a list of all stocks here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html",
-        "# If you don't want the combatlog to be given to players for a certain damage type, simply remove it from this list" })
+        @Description({
+            "# After what type of damage the player should get a combat log?",
+            "# You can find a list of all stocks here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html",
+            "# If you don't want the combatlog to be given to players for a certain damage type, simply remove it from this list"
+        })
         public List<EntityDamageEvent.DamageCause> damageCauses = new ImmutableList.Builder<EntityDamageEvent.DamageCause>()
             .add(EntityDamageEvent.DamageCause.LAVA)
             .add(EntityDamageEvent.DamageCause.CONTACT)
@@ -68,24 +71,71 @@ public class PluginConfig implements ReloadableConfig {
 
     @Contextual
     public static class Messages {
-        public String onlyForPlayers = "&cThis command is only available to players!";
-        public String noPermission = "&cYou don't have permission to perform this command!";
-        public String cantFindPlayer = "&cThe specified player could not be found!";
-        public String playerIsNoInCombat = "&cThis player is not in combat!";
+
+        @Description("# Do you want to change the admin messages?")
+        public Admin admin = new Admin();
+
+        @Description({ " ", "# Combat log message format, eg. on the actionbar (you can use {TIME} variable to display the time left in combat" })
         public String combatFormat = "&dCombat ends in: &f{TIME}";
+
+        @Description("# Message sent when the player does not have permission to perform a command")
+        public String noPermission = "&cYou don't have permission to perform this command!";
+
+        @Description("# Message sent when the player is not in combat")
+        public String cantFindPlayer = "&cThe specified player could not be found!";
+
+        @Description("# Message sent when the player enter to combat")
         public String tagPlayer = "&cYou are in combat, do not leave the server!";
+
+        @Description("# Message sent when the player leave combat")
         public String unTagPlayer = "&aYou are no longer in combat! You can safely leave the server.";
-        public String cantUseCommand = "&cUsing this command during combat is prohibited!";
-        public String adminTagPlayer = "&7You have tagged &e{PLAYER}";
-        public String adminTagPlayerMultiple = "&7You have tagged &e{FIRST_PLAYER}&7 and &e{SECOND_PLAYER}&7.";
-        public String adminUnTagPlayer = "&7You have removed &e{PLAYER}&7 from the fight.";
+
+        @Description("# This is broadcast when the player is in combat and logs out")
         public String playerLoggedInCombat = "&c{PLAYER} logged off during the fight!";
+
+        @Description({
+            "# Message sent when the player is in combat and tries to use a disabled command",
+            "# you can configure the list of disabled commands in the blockedCommands section of the config.yml file"
+        })
+        public String cantUseCommand = "&cUsing this command during combat is prohibited!";
+
+        @Description("# Message sent when player tries to use a command with invalid arguments")
         public String invalidUsage = "&7Correct usage: &e{USAGE}.";
+
+        @Description("# Message sent when player tries to open inventory, but the inventory open is blocked")
         public String inventoryBlocked = "&cYou cannot open this inventory during combat!";
+
+        @Description("# Message sent when player tries to place a block, but the block place is blocked")
         public String blockPlaceBlocked = "&cYou cannot place blocks during combat below 40 blocks!";
-        public String inCombat = "&c{PLAYER} is in the middle of a fight!";
-        public String notInCombat = "&a{PLAYER} is not in combat";
-        public String reload = "&aConfiguration has been successfully reloaded!";
-        public String cantTagSelf = "&cYou cannot tag yourself!";
+
+        @Contextual
+        public static class Admin {
+            @Description("# Message sent when the configuration is reloaded")
+            public String reload = "&aConfiguration has been successfully reloaded!";
+
+            @Description("# Message sent when console tries to use a command that is only for players")
+            public String onlyForPlayers = "&cThis command is only available to players!";
+
+            @Description("# Message sent to admin when they tag a player")
+            public String adminTagPlayer = "&7You have tagged &e{PLAYER}";
+
+            @Description("# Message sent when a player is tagged by an admin")
+            public String adminTagPlayerMultiple = "&7You have tagged &e{FIRST_PLAYER}&7 and &e{SECOND_PLAYER}&7.";
+
+            @Description("# Message sent to admin when they remove a player from combat")
+            public String adminUnTagPlayer = "&7You have removed &e{PLAYER}&7 from the fight.";
+
+            @Description("# Message sent when the player is not in combat")
+            public String adminPlayerIsNoInCombat = "&cThis player is not in combat!";
+
+            @Description("# Message sent when the player is in combat")
+            public String playerInCombat = "&c{PLAYER} is in the middle of a fight!";
+
+            @Description("# Message sent when a player is not in combat")
+            public String adminPlayerNotInCombat = "&a{PLAYER} is not in combat";
+
+            @Description("# Message sent when admin tries to tag themselves")
+            public String adminCantTagSelf = "&cYou cannot tag yourself!";
+        }
     }
 }

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -75,7 +75,7 @@ public class PluginConfig implements ReloadableConfig {
         @Description("# Do you want to change the admin messages?")
         public Admin admin = new Admin();
 
-        @Description({ " ", "# Combat log message format, eg. on the actionbar (you can use {TIME} variable to display the time left in combat" })
+        @Description({ " ", "# Combat log message format, eg. on the actionbar (you can use {TIME} variable to display the time left in combat)" })
         public String combatFormat = "&dCombat ends in: &f{TIME}";
 
         @Description("# Message sent when the player does not have permission to perform a command")


### PR DESCRIPTION
New config:

```yaml
# Do you want to change the plugin settings?
settings:
  # Whether the player after entering the server should receive information about the new version of the plugin?
  receiveUpdates: true
  # The length of time the combat is to last
  combatLogTime: "20s"
  # Combat log notification type, available types: ACTION_BAR, CHAT, TITLE, SUBTITLE
  combatNotificationType: "ACTION_BAR"
  # Blocked commands that the player will not be able to use during combat
  blockedCommands:
    - "gamemode"
    - "tp"
  # Block the opening of inventory?
  blockingInventories: true
  # Whether to block the placement of blocks?
  blockPlace: true
  # From which level should place blocks be blocked?
  blockPlaceLevel: 40
  # Should the option below be enabled?
  enableDamageCauses: true
  # After what type of damage the player should get a combat log?
  # You can find a list of all stocks here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html
  # If you don't want the combatlog to be given to players for a certain damage type, simply remove it from this list
  damageCauses:
    - "LAVA"
    - "CONTACT"
    - "FIRE"
    - "FIRE_TICK"

# Do you want to change the plugin messages?
messages:
  # Do you want to change the admin messages?
  admin:
    # Message sent when the configuration is reloaded
    reload: "&aConfiguration has been successfully reloaded!"
    # Message sent when console tries to use a command that is only for players
    onlyForPlayers: "&cThis command is only available to players!"
    # Message sent to admin when they tag a player
    adminTagPlayer: "&7You have tagged &e{PLAYER}"
    # Message sent when a player is tagged by an admin
    adminTagPlayerMultiple: "&7You have tagged &e{FIRST_PLAYER}&7 and &e{SECOND_PLAYER}&7."
    # Message sent to admin when they remove a player from combat
    adminUnTagPlayer: "&7You have removed &e{PLAYER}&7 from the fight."
    # Message sent when the player is not in combat
    adminPlayerIsNoInCombat: "&cThis player is not in combat!"
    # Message sent when the player is in combat
    playerInCombat: "&c{PLAYER} is in the middle of a fight!"
    # Message sent when a player is not in combat
    adminPlayerNotInCombat: "&a{PLAYER} is not in combat"
    # Message sent when admin tries to tag themselves
    adminCantTagSelf: "&cYou cannot tag yourself!"
  
  # Combat log message format, eg. on the actionbar (you can use {TIME} variable to display the time left in combat
  combatFormat: "&dCombat ends in: &f{TIME}"
  # Message sent when the player does not have permission to perform a command
  noPermission: "&cYou don't have permission to perform this command!"
  # Message sent when the player is not in combat
  cantFindPlayer: "&cThe specified player could not be found!"
  # Message sent when the player enter to combat
  tagPlayer: "&cYou are in combat, do not leave the server!"
  # Message sent when the player leave combat
  unTagPlayer: "&aYou are no longer in combat! You can safely leave the server."
  # This is broadcast when the player is in combat and logs out
  playerLoggedInCombat: "&c{PLAYER} logged off during the fight!"
  # Message sent when the player is in combat and tries to use a disabled command
  # you can configure the list of disabled commands in the blockedCommands section of the config.yml file
  cantUseCommand: "&cUsing this command during combat is prohibited!"
  # Message sent when player tries to use a command with invalid arguments
  invalidUsage: "&7Correct usage: &e{USAGE}."
  # Message sent when player tries to open inventory, but the inventory open is blocked
  inventoryBlocked: "&cYou cannot open this inventory during combat!"
  # Message sent when player tries to place a block, but the block place is blocked
  blockPlaceBlocked: "&cYou cannot place blocks during combat below 40 blocks!"
```  