### PR TITLE
GH-98 Pearl throw control

### DIFF
--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -108,12 +108,9 @@ public class PluginConfig implements ReloadableConfig {
         );
 
         @Description({
-            "# After what type of entity damage should the player get a combat log?",
-            "# You can find a list of all entity types here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html",
-            "# If you don't want the combat log to be given to players for a certain entity type, simply remove it from this list"
-        })
-        public List<EntityType> entityTypesToLog = List.of(
-            EntityType.PLAYER,
+            "# After what type of projectile entity should not tag the player as fighter?",
+            "# You can find a list of all entity types here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html"
+        public List<EntityType> disabledProjectileEntites = List.of(
             EntityType.ENDER_PEARL
         );
     }

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -22,7 +22,7 @@ public class PluginConfig implements ReloadableConfig {
     @Description("# Do you want to change the plugin settings?")
     public Settings settings = new Settings();
 
-    @Description({" ", "# Block the use of ender pearls"})
+    @Description({" ", "# Ender pearl settings"})
     public FightPearlSettings pearl = new FightPearlSettings();
 
     @Description({ " ", "# Set a custom way for a player's items to drop on death (if in combat)" })

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -10,6 +10,7 @@ import net.dzikoysk.cdn.entity.Description;
 import net.dzikoysk.cdn.source.Resource;
 import net.dzikoysk.cdn.source.Source;
 import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 import java.io.File;
@@ -104,6 +105,16 @@ public class PluginConfig implements ReloadableConfig {
             EntityDamageEvent.DamageCause.CONTACT,
             EntityDamageEvent.DamageCause.FIRE,
             EntityDamageEvent.DamageCause.FIRE_TICK
+        );
+
+        @Description({
+            "# After what type of entity damage should the player get a combat log?",
+            "# You can find a list of all entity types here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html",
+            "# If you don't want the combat log to be given to players for a certain entity type, simply remove it from this list"
+        })
+        public List<EntityType> entityTypesToLog = List.of(
+            EntityType.PLAYER,
+            EntityType.ENDER_PEARL
         );
     }
 

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -110,7 +110,8 @@ public class PluginConfig implements ReloadableConfig {
         @Description({
             "# After what type of projectile entity should not tag the player as fighter?",
             "# You can find a list of all entity types here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html"
-        public List<EntityType> disabledProjectileEntites = List.of(
+        })
+        public List<EntityType> disabledProjectileEntities = List.of(
             EntityType.ENDER_PEARL
         );
     }

--- a/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
+++ b/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
@@ -3,6 +3,7 @@ package com.eternalcode.combat.fight.controller;
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
@@ -31,6 +32,13 @@ public class FightTagController implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (!(event.getEntity() instanceof Player attackedPlayerByPerson)) {
+            return;
+        }
+
+        List<EntityType> entityTypes = this.config.settings.entityTypesToLog;
+        EntityType damagerType = event.getDamager().getType();
+
+        if (!entityTypes.contains(damagerType)) {
             return;
         }
 

--- a/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
+++ b/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
@@ -35,9 +35,9 @@ public class FightTagController implements Listener {
             return;
         }
 
-        List<EntityType> disabledProjectileEntites = this.config.settings.disabledProjectileEntites;
+        List<EntityType> disabledProjectileEntities = this.config.settings.disabledProjectileEntities;
         
-        if (event.getDamager() instanceof Projectile projectile && disabledProjectileEntites.contains(projectile.getType())) {
+        if (event.getDamager() instanceof Projectile projectile && disabledProjectileEntities.contains(projectile.getType())) {
             return;
         }
 

--- a/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
+++ b/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
@@ -35,10 +35,9 @@ public class FightTagController implements Listener {
             return;
         }
 
-        List<EntityType> entityTypes = this.config.settings.entityTypesToLog;
-        EntityType damagerType = event.getDamager().getType();
-
-        if (!entityTypes.contains(damagerType)) {
+        List<EntityType> disabledProjectileEntites = this.config.settings.disabledProjectileEntites;
+        
+        if (event.getDamager() instanceof Projectile projectile && disabledProjectileEntites.contains(projectile.getType())) {
             return;
         }
 

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlController.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlController.java
@@ -38,6 +38,10 @@ public class FightPearlController implements Listener {
         Player player = event.getPlayer();
         UUID uniqueId = player.getUniqueId();
 
+        if (!this.settings.pearlThrowBlocked) {
+            return;
+        }
+
         if (!this.fightManager.isInCombat(uniqueId)) {
             return;
         }
@@ -49,10 +53,6 @@ public class FightPearlController implements Listener {
 
         Action action = event.getAction();
         if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
-            return;
-        }
-
-        if (!this.settings.pearlThrowControlEnabled) {
             return;
         }
 
@@ -80,10 +80,6 @@ public class FightPearlController implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     void onEntityDamage(EntityDamageByEntityEvent event) {
-        if (!this.settings.pearlThrowControlEnabled) {
-            return;
-        }
-
         if (this.settings.pearlThrowDamageEnabled) {
             return;
         }

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlController.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlController.java
@@ -78,17 +78,19 @@ public class FightPearlController implements Listener {
         this.fightPearlManager.markDelay(uniqueId);
     }
 
-    @EventHandler(priority = EventPriority.LOW)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     void onEntityDamage(EntityDamageByEntityEvent event) {
         if (!this.settings.pearlThrowControlEnabled) {
             return;
         }
 
-        if (!(event.getEntity() instanceof Player player)) {
+        if (this.settings.pearlThrowDamageEnabled) {
             return;
         }
 
-        UUID playerUniqueId = player.getUniqueId();
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
 
         if (!(event.getDamager() instanceof EnderPearl)) {
             return;
@@ -98,26 +100,6 @@ public class FightPearlController implements Listener {
             return;
         }
 
-        if (!this.settings.pearlThrowMarksCombat) {
-            event.setCancelled(true);
-        }
-
-        if (this.settings.pearlThrowDamageEnabled) {
-            this.damagePlayerIfEventIsCancelled(event, player);
-        }
-        else {
-            if (this.settings.pearlThrowDamageEnabledInCombat && this.fightManager.isInCombat(playerUniqueId)) {
-                this.damagePlayerIfEventIsCancelled(event, player);
-            }
-            else {
-                event.setDamage(0.0D);
-            }
-        }
-    }
-
-    private void damagePlayerIfEventIsCancelled(EntityDamageByEntityEvent event, Player player) {
-        if (event.isCancelled()) {
-            player.damage(event.getFinalDamage());
-        }
+        event.setDamage(0.0D);
     }
 }

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlManager.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlManager.java
@@ -15,12 +15,12 @@ public class FightPearlManager {
     public FightPearlManager(FightPearlSettings pearlSettings) {
         this.pearlSettings = pearlSettings;
         this.pearlDelays = CacheBuilder.newBuilder()
-            .expireAfterWrite(pearlSettings.delay)
+            .expireAfterWrite(pearlSettings.pearlThrowDelay)
             .build();
     }
 
     public void markDelay(UUID uuid) {
-        this.pearlDelays.put(uuid, Instant.now().plus(this.pearlSettings.delay));
+        this.pearlDelays.put(uuid, Instant.now().plus(this.pearlSettings.pearlThrowDelay));
     }
 
     public boolean hasDelay(UUID uuid) {

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
@@ -8,11 +8,11 @@ import java.time.Duration;
 @Contextual
 public class FightPearlSettings {
 
-    @Description("# If you want to completely disable the plugin's pearl throw control, set this to false")
-    public boolean pearlThrowControlEnabled = true;
-
     @Description({ "# Is pearl damage to be enabled?", "# This will work globally" })
     public boolean pearlThrowDamageEnabled = true;
+
+    @Description("# Set true, If you want to lock pearls during the combat")
+    public boolean pearlThrowBlocked = false;
 
     @Description({
         "# Block throwing pearls with delay?",

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
@@ -8,15 +8,24 @@ import java.time.Duration;
 @Contextual
 public class FightPearlSettings {
 
-    @Description("# If you want to completely disable this option, set this to false")
-    public boolean enabled = true;
+    @Description("# If you want to completely disable the plugin's pearl throw control, set this to false")
+    public boolean pearlThrowControlEnabled = true;
+
+    @Description("# Ender pearl throw marks player as in combat?")
+    public boolean pearlThrowMarksCombat = true;
+
+    @Description({ "# Is pearl damage to be enabled?", "# This will work globally" })
+    public boolean pearlThrowDamageEnabled = true;
+
+    @Description({ "# Is pearl damage to be enabled only in combat?", "# This will work only when player is in combat" })
+    public boolean pearlThrowDamageEnabledInCombat = false;
 
     @Description({
         "# Block throwing pearls with delay?",
         "# If you set this to for example 3s, player will have to wait 3 seconds before throwing another pearl",
         "# Set to 0 to disable"
     })
-    public Duration delay = Duration.ofSeconds(3);
+    public Duration pearlThrowDelay = Duration.ofSeconds(3);
 
     @Description("# Message sent when player tries to throw ender pearl, but are disabled")
     public String pearlThrowBlockedDuringCombat = "&cThrowing ender pearls is prohibited during combat!";

--- a/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
+++ b/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
@@ -11,14 +11,8 @@ public class FightPearlSettings {
     @Description("# If you want to completely disable the plugin's pearl throw control, set this to false")
     public boolean pearlThrowControlEnabled = true;
 
-    @Description("# Ender pearl throw marks player as in combat?")
-    public boolean pearlThrowMarksCombat = true;
-
     @Description({ "# Is pearl damage to be enabled?", "# This will work globally" })
     public boolean pearlThrowDamageEnabled = true;
-
-    @Description({ "# Is pearl damage to be enabled only in combat?", "# This will work only when player is in combat" })
-    public boolean pearlThrowDamageEnabledInCombat = false;
 
     @Description({
         "# Block throwing pearls with delay?",


### PR DESCRIPTION
Add an option to the configuration whether the player should receive combat status and damage after pearl throw.
Tested on localhost.
Fixes #98.