### PR TITLE
GH-86 Add a bossbar implementation

### DIFF
--- a/src/main/java/com/eternalcode/combat/CombatCommand.java
+++ b/src/main/java/com/eternalcode/combat/CombatCommand.java
@@ -3,6 +3,7 @@ package com.eternalcode.combat;
 import com.eternalcode.combat.config.ConfigService;
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.combat.fight.FightManager;
+import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
 import dev.rollczi.litecommands.argument.Arg;
 import dev.rollczi.litecommands.command.async.Async;
@@ -21,12 +22,14 @@ public class CombatCommand {
 
     private final FightManager fightManager;
     private final ConfigService configService;
+    private final FightBossBarService bossBarService;
     private final NotificationAnnouncer announcer;
     private final PluginConfig config;
 
-    public CombatCommand(FightManager fightManager, ConfigService configService, NotificationAnnouncer announcer, PluginConfig config) {
+    public CombatCommand(FightManager fightManager, ConfigService configService, FightBossBarService bossBarService, NotificationAnnouncer announcer, PluginConfig config) {
         this.fightManager = fightManager;
         this.configService = configService;
+        this.bossBarService = bossBarService;
         this.announcer = announcer;
         this.config = config;
     }
@@ -100,7 +103,9 @@ public class CombatCommand {
         }
 
         this.announcer.sendMessage(target, this.config.messages.playerUntagged);
+
         this.fightManager.untag(targetUniqueId);
+        this.bossBarService.hide(targetUniqueId);
 
         Formatter formatter = new Formatter()
             .register("{PLAYER}", target.getName());

--- a/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -12,6 +12,8 @@ import com.eternalcode.combat.drop.impl.PercentDropModifier;
 import com.eternalcode.combat.drop.impl.PlayersHealthDropModifier;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.fight.FightTask;
+import com.eternalcode.combat.fight.bossbar.FightBossBarManager;
+import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.fight.controller.FightActionBlockerController;
 import com.eternalcode.combat.fight.controller.FightDeathCauseController;
 import com.eternalcode.combat.fight.controller.FightEscapeController;
@@ -47,6 +49,9 @@ public final class CombatPlugin extends JavaPlugin {
     private FightManager fightManager;
     private FightPearlManager fightPearlManager;
 
+    private FightBossBarManager fightBossBarManager;
+    private FightBossBarService fightBossBarService;
+
     private AudienceProvider audienceProvider;
     private LiteCommands<CommandSender> liteCommands;
 
@@ -72,10 +77,14 @@ public final class CombatPlugin extends JavaPlugin {
             .postProcessor(new LegacyColorProcessor())
             .build();
 
+        this.fightBossBarManager = new FightBossBarManager();
+        this.fightBossBarService = new FightBossBarService(pluginConfig, this.fightBossBarManager, this.audienceProvider, miniMessage);
+
         BridgeService bridgeService = new BridgeService(pluginConfig, server.getPluginManager(), this.getLogger());
         bridgeService.init();
 
         NotificationAnnouncer notificationAnnouncer = new NotificationAnnouncer(this.audienceProvider, miniMessage);
+
         this.liteCommands = LiteBukkitAdventurePlatformFactory.builder(server, "eternalcombat", this.audienceProvider)
             .argument(Player.class, new BukkitPlayerArgument<>(this.getServer(), pluginConfig.messages.playerNotFound))
             .contextualBind(Player.class, new BukkitOnlyPlayerContextual<>(pluginConfig.messages.admin.onlyForPlayers))
@@ -87,7 +96,7 @@ public final class CombatPlugin extends JavaPlugin {
 
             .register();
 
-        FightTask fightTask = new FightTask(this.fightManager, pluginConfig, server, notificationAnnouncer);
+        FightTask fightTask = new FightTask(server, pluginConfig, this.fightManager, this.fightBossBarManager, this.fightBossBarService, notificationAnnouncer);
         this.getServer().getScheduler().runTaskTimerAsynchronously(this, fightTask, 20L, 20L);
 
         new Metrics(this, 17803);

--- a/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -12,7 +12,6 @@ import com.eternalcode.combat.drop.impl.PercentDropModifier;
 import com.eternalcode.combat.drop.impl.PlayersHealthDropModifier;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.fight.FightTask;
-import com.eternalcode.combat.fight.bossbar.FightBossBarRegistry;
 import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.fight.controller.FightActionBlockerController;
 import com.eternalcode.combat.fight.controller.FightDeathCauseController;
@@ -49,7 +48,6 @@ public final class CombatPlugin extends JavaPlugin {
     private FightManager fightManager;
     private FightPearlManager fightPearlManager;
 
-    private FightBossBarRegistry fightBossBarRegistry;
     private FightBossBarService fightBossBarService;
 
     private AudienceProvider audienceProvider;
@@ -77,8 +75,7 @@ public final class CombatPlugin extends JavaPlugin {
             .postProcessor(new LegacyColorProcessor())
             .build();
 
-        this.fightBossBarRegistry = new FightBossBarRegistry();
-        this.fightBossBarService = new FightBossBarService(pluginConfig, this.fightBossBarRegistry, this.audienceProvider, miniMessage);
+        this.fightBossBarService = new FightBossBarService(pluginConfig, this.audienceProvider, miniMessage);
 
         BridgeService bridgeService = new BridgeService(pluginConfig, server.getPluginManager(), this.getLogger());
         bridgeService.init();
@@ -96,7 +93,7 @@ public final class CombatPlugin extends JavaPlugin {
 
             .register();
 
-        FightTask fightTask = new FightTask(server, pluginConfig, this.fightManager, this.fightBossBarRegistry, this.fightBossBarService, notificationAnnouncer);
+        FightTask fightTask = new FightTask(server, pluginConfig, this.fightManager, this.fightBossBarService, notificationAnnouncer);
         this.getServer().getScheduler().runTaskTimerAsynchronously(this, fightTask, 20L, 20L);
 
         new Metrics(this, 17803);

--- a/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -12,7 +12,7 @@ import com.eternalcode.combat.drop.impl.PercentDropModifier;
 import com.eternalcode.combat.drop.impl.PlayersHealthDropModifier;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.fight.FightTask;
-import com.eternalcode.combat.fight.bossbar.FightBossBarManager;
+import com.eternalcode.combat.fight.bossbar.FightBossBarRegistry;
 import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.fight.controller.FightActionBlockerController;
 import com.eternalcode.combat.fight.controller.FightDeathCauseController;
@@ -49,7 +49,7 @@ public final class CombatPlugin extends JavaPlugin {
     private FightManager fightManager;
     private FightPearlManager fightPearlManager;
 
-    private FightBossBarManager fightBossBarManager;
+    private FightBossBarRegistry fightBossBarRegistry;
     private FightBossBarService fightBossBarService;
 
     private AudienceProvider audienceProvider;
@@ -77,8 +77,8 @@ public final class CombatPlugin extends JavaPlugin {
             .postProcessor(new LegacyColorProcessor())
             .build();
 
-        this.fightBossBarManager = new FightBossBarManager();
-        this.fightBossBarService = new FightBossBarService(pluginConfig, this.fightBossBarManager, this.audienceProvider, miniMessage);
+        this.fightBossBarRegistry = new FightBossBarRegistry();
+        this.fightBossBarService = new FightBossBarService(pluginConfig, this.fightBossBarRegistry, this.audienceProvider, miniMessage);
 
         BridgeService bridgeService = new BridgeService(pluginConfig, server.getPluginManager(), this.getLogger());
         bridgeService.init();
@@ -96,7 +96,7 @@ public final class CombatPlugin extends JavaPlugin {
 
             .register();
 
-        FightTask fightTask = new FightTask(server, pluginConfig, this.fightManager, this.fightBossBarManager, this.fightBossBarService, notificationAnnouncer);
+        FightTask fightTask = new FightTask(server, pluginConfig, this.fightManager, this.fightBossBarRegistry, this.fightBossBarService, notificationAnnouncer);
         this.getServer().getScheduler().runTaskTimerAsynchronously(this, fightTask, 20L, 20L);
 
         new Metrics(this, 17803);

--- a/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -89,7 +89,7 @@ public final class CombatPlugin extends JavaPlugin {
             .invalidUsageHandler(new InvalidUsage(pluginConfig, notificationAnnouncer))
             .permissionHandler(new PermissionMessage(pluginConfig, notificationAnnouncer))
 
-            .commandInstance(new CombatCommand(this.fightManager, configService, notificationAnnouncer, pluginConfig))
+            .commandInstance(new CombatCommand(this.fightManager, configService, this.fightBossBarService, notificationAnnouncer, pluginConfig))
 
             .register();
 

--- a/src/main/java/com/eternalcode/combat/config/ConfigService.java
+++ b/src/main/java/com/eternalcode/combat/config/ConfigService.java
@@ -1,5 +1,6 @@
 package com.eternalcode.combat.config;
 
+import com.eternalcode.combat.notification.serializer.NotificationSerializer;
 import eu.okaeri.configs.ConfigManager;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.serdes.commons.SerdesCommons;
@@ -25,6 +26,10 @@ public class ConfigService {
         T configFile = ConfigManager.create(config);
 
         configFile.withConfigurer(new YamlBukkitConfigurer(), new SerdesCommons());
+        configFile.withSerdesPack(registry -> {
+            registry.register(new NotificationSerializer());
+        });
+
         configFile.withBindFile(file);
         configFile.withRemoveOrphans(true);
         configFile.saveDefaults();

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -3,7 +3,8 @@ package com.eternalcode.combat.config.implementation;
 import com.eternalcode.combat.WhitelistBlacklistMode;
 import com.eternalcode.combat.drop.DropSettings;
 import com.eternalcode.combat.fight.pearl.FightPearlSettings;
-import com.eternalcode.combat.notification.NotificationType;
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.implementation.ActionBarNotification;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
 import org.bukkit.Material;
@@ -49,9 +50,6 @@ public class PluginConfig extends OkaeriConfig {
 
         @Comment("# Release attacker after victim dies?")
         public boolean shouldReleaseAttacker = true;
-
-        @Comment("# Combat log notification type, available types: ACTION_BAR, CHAT, TITLE, SUBTITLE")
-        public NotificationType notificationType = NotificationType.ACTION_BAR;
 
         @Comment("# Command blocking mode, available modes: WHITELIST, BLACKLIST")
         public WhitelistBlacklistMode commandBlockingMode = WhitelistBlacklistMode.BLACKLIST;
@@ -126,8 +124,13 @@ public class PluginConfig extends OkaeriConfig {
         @Comment("# Do you want to change the admin messages?")
         public AdminMessages admin = new AdminMessages();
 
-        @Comment({ " ", "# Combat log message format, e.g. on the actionbar (you can use {TIME} variable to display the time left in combat)" })
-        public String combatFormat = "&dCombat ends in: &f{TIME}";
+        @Comment({
+            " ",
+            "# Combat log notification",
+            "# You can use {TIME} variable to display the time left in combat" ,
+            "# Notification types: CHAT, ACTION_BAR, TITLE, SUB_TITLE, BOSS_BAR",
+        })
+        public Notification combatNotification = new ActionBarNotification("&dCombat ends in: &f{TIME}");
 
         @Comment("# Message sent when the player does not have permission to perform a command")
         public String noPermission = "&cYou don't have permission to perform this command!";

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -129,6 +129,10 @@ public class PluginConfig extends OkaeriConfig {
             "# Combat log notification",
             "# You can use {TIME} variable to display the time left in combat",
             "# Notification types: CHAT, ACTION_BAR, TITLE, SUB_TITLE, BOSS_BAR",
+            " ",
+            "# BossBar progress: This is the value of the progress bar. Set it to -1.0 to show the remaining combat time",
+            "# BossBar colors: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Color.html",
+            "# BossBar overlays: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Overlay.html"
         })
         public Notification combatNotification = new ActionBarNotification("&dCombat ends in: &f{TIME}");
 

--- a/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -127,7 +127,7 @@ public class PluginConfig extends OkaeriConfig {
         @Comment({
             " ",
             "# Combat log notification",
-            "# You can use {TIME} variable to display the time left in combat" ,
+            "# You can use {TIME} variable to display the time left in combat",
             "# Notification types: CHAT, ACTION_BAR, TITLE, SUB_TITLE, BOSS_BAR",
         })
         public Notification combatNotification = new ActionBarNotification("&dCombat ends in: &f{TIME}");

--- a/src/main/java/com/eternalcode/combat/fight/FightManager.java
+++ b/src/main/java/com/eternalcode/combat/fight/FightManager.java
@@ -19,12 +19,7 @@ public class FightManager {
 
         FightTag fightTag = this.fights.get(player);
 
-        if (fightTag.isExpired()) {
-            this.fights.remove(player);
-            return false;
-        }
-
-        return true;
+        return !fightTag.isExpired();
     }
 
     public void untag(UUID player) {

--- a/src/main/java/com/eternalcode/combat/fight/FightTag.java
+++ b/src/main/java/com/eternalcode/combat/fight/FightTag.java
@@ -24,6 +24,10 @@ public class FightTag {
         return this.taggedPlayer;
     }
 
+    public Instant getEndOfCombatLog() {
+        return this.endOfCombatLog;
+    }
+
     public boolean isExpired() {
         return Instant.now().isAfter(this.endOfCombatLog);
     }

--- a/src/main/java/com/eternalcode/combat/fight/FightTask.java
+++ b/src/main/java/com/eternalcode/combat/fight/FightTask.java
@@ -1,7 +1,6 @@
 package com.eternalcode.combat.fight;
 
 import com.eternalcode.combat.config.implementation.PluginConfig;
-import com.eternalcode.combat.fight.bossbar.FightBossBarRegistry;
 import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.notification.Notification;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
@@ -19,15 +18,13 @@ public class FightTask implements Runnable {
     private final Server server;
     private final PluginConfig config;
     private final FightManager fightManager;
-    private final FightBossBarRegistry bossBarManager;
     private final FightBossBarService bossBarService;
     private final NotificationAnnouncer announcer;
 
-    public FightTask(Server server, PluginConfig config, FightManager fightManager, FightBossBarRegistry bossBarManager, FightBossBarService bossBarService, NotificationAnnouncer announcer) {
+    public FightTask(Server server, PluginConfig config, FightManager fightManager, FightBossBarService bossBarService, NotificationAnnouncer announcer) {
         this.server = server;
         this.config = config;
         this.fightManager = fightManager;
-        this.bossBarManager = bossBarManager;
         this.bossBarService = bossBarService;
         this.announcer = announcer;
     }
@@ -58,9 +55,7 @@ public class FightTask implements Runnable {
             this.announcer.sendMessage(player, this.config.messages.playerUntagged);
 
             this.fightManager.untag(playerUniqueId);
-
-            this.bossBarManager.getFightBossBar(playerUniqueId)
-                .ifPresent(fightBossBar -> this.bossBarService.hide(fightTag, fightBossBar));
+            this.bossBarService.hide(playerUniqueId);
         }
     }
 

--- a/src/main/java/com/eternalcode/combat/fight/FightTask.java
+++ b/src/main/java/com/eternalcode/combat/fight/FightTask.java
@@ -1,7 +1,7 @@
 package com.eternalcode.combat.fight;
 
 import com.eternalcode.combat.config.implementation.PluginConfig;
-import com.eternalcode.combat.fight.bossbar.FightBossBarManager;
+import com.eternalcode.combat.fight.bossbar.FightBossBarRegistry;
 import com.eternalcode.combat.fight.bossbar.FightBossBarService;
 import com.eternalcode.combat.notification.Notification;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
@@ -19,11 +19,11 @@ public class FightTask implements Runnable {
     private final Server server;
     private final PluginConfig config;
     private final FightManager fightManager;
-    private final FightBossBarManager bossBarManager;
+    private final FightBossBarRegistry bossBarManager;
     private final FightBossBarService bossBarService;
     private final NotificationAnnouncer announcer;
 
-    public FightTask(Server server, PluginConfig config, FightManager fightManager, FightBossBarManager bossBarManager, FightBossBarService bossBarService, NotificationAnnouncer announcer) {
+    public FightTask(Server server, PluginConfig config, FightManager fightManager, FightBossBarRegistry bossBarManager, FightBossBarService bossBarService, NotificationAnnouncer announcer) {
         this.server = server;
         this.config = config;
         this.fightManager = fightManager;

--- a/src/main/java/com/eternalcode/combat/fight/FightTask.java
+++ b/src/main/java/com/eternalcode/combat/fight/FightTask.java
@@ -1,25 +1,34 @@
 package com.eternalcode.combat.fight;
 
 import com.eternalcode.combat.config.implementation.PluginConfig;
+import com.eternalcode.combat.fight.bossbar.FightBossBarManager;
+import com.eternalcode.combat.fight.bossbar.FightBossBarService;
+import com.eternalcode.combat.notification.Notification;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
+import com.eternalcode.combat.notification.implementation.BossBarNotification;
 import com.eternalcode.combat.util.DurationUtil;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import panda.utilities.text.Formatter;
 
 import java.time.Duration;
+import java.util.UUID;
 
 public class FightTask implements Runnable {
 
-    private final FightManager fightManager;
-    private final PluginConfig config;
     private final Server server;
+    private final PluginConfig config;
+    private final FightManager fightManager;
+    private final FightBossBarManager bossBarManager;
+    private final FightBossBarService bossBarService;
     private final NotificationAnnouncer announcer;
 
-    public FightTask(FightManager fightManager, PluginConfig config, Server server, NotificationAnnouncer announcer) {
-        this.fightManager = fightManager;
-        this.config = config;
+    public FightTask(Server server, PluginConfig config, FightManager fightManager, FightBossBarManager bossBarManager, FightBossBarService bossBarService, NotificationAnnouncer announcer) {
         this.server = server;
+        this.config = config;
+        this.fightManager = fightManager;
+        this.bossBarManager = bossBarManager;
+        this.bossBarService = bossBarService;
         this.announcer = announcer;
     }
 
@@ -32,20 +41,35 @@ public class FightTask implements Runnable {
                 return;
             }
 
+            UUID playerUniqueId = player.getUniqueId();
+
             if (!fightTag.isExpired()) {
                 Duration remaining = fightTag.getRemainingDuration();
 
                 Formatter formatter = new Formatter()
                     .register("{TIME}", DurationUtil.format(remaining));
 
-                String format = formatter.format(this.config.messages.combatFormat);
-                this.announcer.send(player, this.config.settings.notificationType, format);
+                Notification combatNotification = this.config.messages.combatNotification;
 
+                this.sendFightNotification(player, fightTag, combatNotification, formatter);
                 continue;
             }
 
-            this.fightManager.untag(fightTag.getTaggedPlayer());
-            this.announcer.send(player, this.config.settings.notificationType, this.config.messages.playerUntagged);
+            this.announcer.sendMessage(player, this.config.messages.playerUntagged);
+
+            this.fightManager.untag(playerUniqueId);
+
+            this.bossBarManager.getFightBossBar(playerUniqueId)
+                .ifPresent(fightBossBar -> this.bossBarService.hide(fightTag, fightBossBar));
         }
+    }
+
+    private void sendFightNotification(Player player, FightTag fightTag, Notification notification, Formatter formatter) {
+        if (notification instanceof BossBarNotification bossBarNotification) {
+            this.bossBarService.send(player, fightTag, bossBarNotification, formatter);
+            return;
+        }
+
+        this.announcer.send(player, notification, formatter);
     }
 }

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBar.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBar.java
@@ -5,5 +5,5 @@ import net.kyori.adventure.bossbar.BossBar;
 
 import java.time.Duration;
 
-public record FightBossBar(Audience audience, BossBar bossBar, Duration combatDuration) {
+public record FightBossBar(Audience audience, BossBar bossBar, float progress, Duration combatDuration) {
 }

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBar.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBar.java
@@ -1,0 +1,9 @@
+package com.eternalcode.combat.fight.bossbar;
+
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
+
+import java.time.Duration;
+
+public record FightBossBar(Audience audience, BossBar bossBar, Duration combatDuration) {
+}

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarManager.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarManager.java
@@ -1,0 +1,27 @@
+package com.eternalcode.combat.fight.bossbar;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FightBossBarManager {
+
+    private final Map<UUID, FightBossBar> fightBossBars = new ConcurrentHashMap<>();
+
+    public void add(UUID uuid, FightBossBar fightBossBar) {
+        this.fightBossBars.put(uuid, fightBossBar);
+    }
+
+    public void remove(UUID uuid) {
+        this.fightBossBars.remove(uuid);
+    }
+
+    public boolean hasFightBossBar(UUID uuid) {
+        return this.fightBossBars.containsKey(uuid);
+    }
+
+    public Optional<FightBossBar> getFightBossBar(UUID uuid) {
+        return Optional.ofNullable(this.fightBossBars.get(uuid));
+    }
+}

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarRegistry.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarRegistry.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class FightBossBarManager {
+public class FightBossBarRegistry {
 
     private final Map<UUID, FightBossBar> fightBossBars = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarRegistry.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarRegistry.java
@@ -5,23 +5,23 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class FightBossBarRegistry {
+class FightBossBarRegistry {
 
     private final Map<UUID, FightBossBar> fightBossBars = new ConcurrentHashMap<>();
 
-    public void add(UUID uuid, FightBossBar fightBossBar) {
+    void add(UUID uuid, FightBossBar fightBossBar) {
         this.fightBossBars.put(uuid, fightBossBar);
     }
 
-    public void remove(UUID uuid) {
+    void remove(UUID uuid) {
         this.fightBossBars.remove(uuid);
     }
 
-    public boolean hasFightBossBar(UUID uuid) {
+    boolean hasFightBossBar(UUID uuid) {
         return this.fightBossBars.containsKey(uuid);
     }
 
-    public Optional<FightBossBar> getFightBossBar(UUID uuid) {
+    Optional<FightBossBar> getFightBossBar(UUID uuid) {
         return Optional.ofNullable(this.fightBossBars.get(uuid));
     }
 }

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarService.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarService.java
@@ -18,11 +18,11 @@ import java.util.UUID;
 public class FightBossBarService {
 
     private final PluginConfig pluginConfig;
-    private final FightBossBarManager bossBarManager;
+    private final FightBossBarRegistry bossBarManager;
     private final AudienceProvider audienceProvider;
     private final MiniMessage miniMessage;
 
-    public FightBossBarService(PluginConfig pluginConfig, FightBossBarManager bossBarManager, AudienceProvider audienceProvider, MiniMessage miniMessage) {
+    public FightBossBarService(PluginConfig pluginConfig, FightBossBarRegistry bossBarManager, AudienceProvider audienceProvider, MiniMessage miniMessage) {
         this.pluginConfig = pluginConfig;
         this.bossBarManager = bossBarManager;
         this.audienceProvider = audienceProvider;

--- a/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarService.java
+++ b/src/main/java/com/eternalcode/combat/fight/bossbar/FightBossBarService.java
@@ -1,0 +1,100 @@
+package com.eternalcode.combat.fight.bossbar;
+
+import com.eternalcode.combat.config.implementation.PluginConfig;
+import com.eternalcode.combat.fight.FightTag;
+import com.eternalcode.combat.notification.implementation.BossBarNotification;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.platform.AudienceProvider;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.entity.Player;
+import panda.utilities.text.Formatter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+public class FightBossBarService {
+
+    private final PluginConfig pluginConfig;
+    private final FightBossBarManager bossBarManager;
+    private final AudienceProvider audienceProvider;
+    private final MiniMessage miniMessage;
+
+    public FightBossBarService(PluginConfig pluginConfig, FightBossBarManager bossBarManager, AudienceProvider audienceProvider, MiniMessage miniMessage) {
+        this.pluginConfig = pluginConfig;
+        this.bossBarManager = bossBarManager;
+        this.audienceProvider = audienceProvider;
+        this.miniMessage = miniMessage;
+    }
+
+    public void show(Player player, FightBossBar fightBossBar) {
+        UUID playerUniqueId = player.getUniqueId();
+
+        Audience audience = this.audienceProvider.player(playerUniqueId);
+        BossBar bossBar = fightBossBar.bossBar();
+
+        audience.showBossBar(bossBar);
+        this.bossBarManager.add(playerUniqueId, fightBossBar);
+    }
+
+    public void hide(FightTag fightTag, FightBossBar fightBossBar) {
+        Audience audience = fightBossBar.audience();
+        BossBar bossBar = fightBossBar.bossBar();
+        UUID taggedPlayer = fightTag.getTaggedPlayer();
+
+        audience.hideBossBar(bossBar);
+        this.bossBarManager.remove(taggedPlayer);
+    }
+
+    public void update(FightTag fightTag, FightBossBar fightBossBar, String message) {
+        BossBar bossBar = fightBossBar.bossBar();
+
+        if (fightTag.isExpired()) {
+            this.hide(fightTag, fightBossBar);
+            return;
+        }
+
+        Component name = this.miniMessage.deserialize(message);
+
+        Instant now = Instant.now();
+        Instant endOfCombatLog = fightTag.getEndOfCombatLog();
+
+        Duration between = Duration.between(now, endOfCombatLog);
+        Duration combatDuration = fightBossBar.combatDuration();
+
+        float difference = (float) between.toMillis() / combatDuration.toMillis();
+        float progress = Math.max(0.0F, Math.min(1.0F, difference));
+
+        bossBar.name(name);
+        bossBar.progress(progress);
+    }
+
+    public void send(Player player, FightTag fightTag, BossBarNotification bossBarNotification, Formatter formatter) {
+        UUID playerUniqueId = player.getUniqueId();
+
+        FightBossBar fightBossBar = this.bossBarManager.getFightBossBar(playerUniqueId)
+            .orElseGet(() -> this.create(player, bossBarNotification, formatter));
+
+        if (!this.bossBarManager.hasFightBossBar(playerUniqueId)) {
+            this.show(player, fightBossBar);
+            return;
+        }
+
+        String message = formatter.format(bossBarNotification.message());
+
+        this.update(fightTag, fightBossBar, message);
+    }
+
+    public FightBossBar create(Player player, BossBarNotification bossBarNotification, Formatter formatter) {
+        Audience audience = this.audienceProvider.player(player.getUniqueId());
+
+        Component name = this.miniMessage.deserialize(formatter.format(bossBarNotification.message()));
+        BossBar bossBar = bossBarNotification.create(name);
+
+        Duration combatDuration = this.pluginConfig.settings.combatDuration;
+
+        return new FightBossBar(audience, bossBar, combatDuration);
+    }
+}

--- a/src/main/java/com/eternalcode/combat/fight/controller/FightEscapeController.java
+++ b/src/main/java/com/eternalcode/combat/fight/controller/FightEscapeController.java
@@ -35,7 +35,7 @@ public class FightEscapeController implements Listener {
 
         String format = formatter.format(this.config.messages.playerLoggedOutDuringCombat);
 
-        this.announcer.broadcast(player, format);
+        this.announcer.broadcast(format);
 
         FightTag fightTag = this.fightManager.getTag(player.getUniqueId());
         fightTag.setHealthBeforeDeath(player.getHealth());

--- a/src/main/java/com/eternalcode/combat/notification/Notification.java
+++ b/src/main/java/com/eternalcode/combat/notification/Notification.java
@@ -1,0 +1,8 @@
+package com.eternalcode.combat.notification;
+
+public interface Notification {
+
+    String message();
+
+    NotificationType type();
+}

--- a/src/main/java/com/eternalcode/combat/notification/NotificationAnnouncer.java
+++ b/src/main/java/com/eternalcode/combat/notification/NotificationAnnouncer.java
@@ -1,24 +1,17 @@
 package com.eternalcode.combat.notification;
 
+import com.eternalcode.combat.notification.implementation.BossBarNotification;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.platform.AudienceProvider;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.title.Title;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.Map;
-import java.util.function.BiConsumer;
+import panda.utilities.text.Formatter;
 
 public final class NotificationAnnouncer {
-
-    private final static Map<NotificationType, BiConsumer<Audience, Component>> NOTIFICATION_HANDLERS = Map.of(
-        NotificationType.CHAT, Audience::sendMessage,
-        NotificationType.ACTION_BAR, Audience::sendActionBar,
-        NotificationType.TITLE, (audience, component) -> audience.showTitle(Title.title(component, Component.empty())),
-        NotificationType.SUBTITLE, (audience, component) -> audience.showTitle(Title.title(Component.empty(), component))
-    );
 
     private final AudienceProvider audienceProvider;
     private final MiniMessage miniMessage;
@@ -28,27 +21,52 @@ public final class NotificationAnnouncer {
         this.miniMessage = miniMessage;
     }
 
-    public void send(CommandSender commandSender, NotificationType notificationType, String text) {
-        Audience audience = this.audience(commandSender);
-        Component component = this.miniMessage.deserialize(text);
+    public void send(CommandSender sender, Notification notification, Formatter formatter) {
+        Audience audience = this.audience(sender);
+        Component message = this.miniMessage.deserialize(formatter.format(notification.message()));
 
-        BiConsumer<Audience, Component> handler = NOTIFICATION_HANDLERS.get(notificationType);
+        NotificationType type = notification.type();
 
-        if (handler == null) {
-            return;
+        switch (type) {
+            case CHAT -> audience.sendMessage(message);
+            case ACTION_BAR -> audience.sendActionBar(message);
+
+            case TITLE -> {
+                Title title = Title.title(message, Component.empty());
+
+                audience.showTitle(title);
+            }
+
+            case SUB_TITLE -> {
+                Title subTitle = Title.title(Component.empty(), message);
+
+                audience.showTitle(subTitle);
+            }
+
+            case BOSS_BAR -> {
+                BossBarNotification bossBarNotification = (BossBarNotification) notification;
+
+                BossBar bossBar = bossBarNotification.create(message);
+
+                audience.showBossBar(bossBar);
+            }
+
+            default -> throw new IllegalStateException("Unknown notification type: " + type);
         }
-
-        handler.accept(audience, component);
     }
 
     public void sendMessage(CommandSender commandSender, String text) {
         Audience audience = this.audience(commandSender);
+        Component message = this.miniMessage.deserialize(text);
 
-        audience.sendMessage(this.miniMessage.deserialize(text));
+        audience.sendMessage(message);
     }
 
-    public void broadcast(CommandSender commandSender, String text) {
-        this.audienceProvider.all().sendMessage(this.miniMessage.deserialize(text));
+    public void broadcast(String text) {
+        Audience audience = this.audienceProvider.all();
+        Component message = this.miniMessage.deserialize(text);
+
+        audience.sendMessage(message);
     }
 
     private Audience audience(CommandSender sender) {

--- a/src/main/java/com/eternalcode/combat/notification/NotificationType.java
+++ b/src/main/java/com/eternalcode/combat/notification/NotificationType.java
@@ -1,9 +1,9 @@
 package com.eternalcode.combat.notification;
 
 public enum NotificationType {
-    ACTION_BAR,
     CHAT,
+    ACTION_BAR,
     TITLE,
-    SUBTITLE,
+    SUB_TITLE,
     BOSS_BAR
 }

--- a/src/main/java/com/eternalcode/combat/notification/implementation/ActionBarNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/ActionBarNotification.java
@@ -1,0 +1,12 @@
+package com.eternalcode.combat.notification.implementation;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+
+public record ActionBarNotification(String message) implements Notification {
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.ACTION_BAR;
+    }
+}

--- a/src/main/java/com/eternalcode/combat/notification/implementation/BossBarNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/BossBarNotification.java
@@ -1,0 +1,18 @@
+package com.eternalcode.combat.notification.implementation;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.text.Component;
+
+public record BossBarNotification(String message, float progress, BossBar.Color color, BossBar.Overlay overlay) implements Notification {
+
+    public BossBar create(Component name) {
+        return BossBar.bossBar(name, this.progress, this.color, this.overlay);
+    }
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.BOSS_BAR;
+    }
+}

--- a/src/main/java/com/eternalcode/combat/notification/implementation/BossBarNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/BossBarNotification.java
@@ -8,7 +8,9 @@ import net.kyori.adventure.text.Component;
 public record BossBarNotification(String message, float progress, BossBar.Color color, BossBar.Overlay overlay) implements Notification {
 
     public BossBar create(Component name) {
-        return BossBar.bossBar(name, this.progress, this.color, this.overlay);
+        float replacedProgress = this.progress < 0.0F ? BossBar.MAX_PROGRESS : this.progress;
+
+        return BossBar.bossBar(name, replacedProgress, this.color, this.overlay);
     }
 
     @Override

--- a/src/main/java/com/eternalcode/combat/notification/implementation/ChatNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/ChatNotification.java
@@ -1,0 +1,12 @@
+package com.eternalcode.combat.notification.implementation;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+
+public record ChatNotification(String message) implements Notification {
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.CHAT;
+    }
+}

--- a/src/main/java/com/eternalcode/combat/notification/implementation/SubTitleNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/SubTitleNotification.java
@@ -1,0 +1,12 @@
+package com.eternalcode.combat.notification.implementation;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+
+public record SubTitleNotification(String message) implements Notification {
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.SUB_TITLE;
+    }
+}

--- a/src/main/java/com/eternalcode/combat/notification/implementation/TitleNotification.java
+++ b/src/main/java/com/eternalcode/combat/notification/implementation/TitleNotification.java
@@ -1,0 +1,12 @@
+package com.eternalcode.combat.notification.implementation;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+
+public record TitleNotification(String message) implements Notification {
+
+    @Override
+    public NotificationType type() {
+        return NotificationType.TITLE;
+    }
+}

--- a/src/main/java/com/eternalcode/combat/notification/serializer/NotificationSerializer.java
+++ b/src/main/java/com/eternalcode/combat/notification/serializer/NotificationSerializer.java
@@ -1,0 +1,64 @@
+package com.eternalcode.combat.notification.serializer;
+
+import com.eternalcode.combat.notification.Notification;
+import com.eternalcode.combat.notification.NotificationType;
+import com.eternalcode.combat.notification.implementation.ActionBarNotification;
+import com.eternalcode.combat.notification.implementation.BossBarNotification;
+import com.eternalcode.combat.notification.implementation.ChatNotification;
+import com.eternalcode.combat.notification.implementation.SubTitleNotification;
+import com.eternalcode.combat.notification.implementation.TitleNotification;
+import eu.okaeri.configs.schema.GenericsDeclaration;
+import eu.okaeri.configs.serdes.DeserializationData;
+import eu.okaeri.configs.serdes.ObjectSerializer;
+import eu.okaeri.configs.serdes.SerializationData;
+import net.kyori.adventure.bossbar.BossBar;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Optional;
+
+public class NotificationSerializer implements ObjectSerializer<Notification> {
+    
+    @Override
+    public boolean supports(@NonNull Class<? super Notification> type) {
+        return Notification.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void serialize(@NonNull Notification notification, @NonNull SerializationData data, @NonNull GenericsDeclaration generics) {
+        data.add("type", notification.type(), NotificationType.class);
+        data.add("message", notification.message(), String.class);
+
+        if (notification instanceof BossBarNotification bossBarNotification) {
+            data.add("progress", bossBarNotification.progress(), float.class);
+            data.add("color", bossBarNotification.color(), BossBar.Color.class);
+            data.add("overlay", bossBarNotification.overlay(), BossBar.Overlay.class);
+        }
+    }
+
+    @Override
+    public Notification deserialize(@NonNull DeserializationData data, @NonNull GenericsDeclaration generics) {
+        NotificationType type = data.get("type", NotificationType.class);
+        String message = data.get("message", String.class);
+
+        return switch (type) {
+            case CHAT -> new ChatNotification(message);
+            case ACTION_BAR -> new ActionBarNotification(message);
+
+            case TITLE -> new TitleNotification(message);
+            case SUB_TITLE -> new SubTitleNotification(message);
+
+            case BOSS_BAR -> {
+                float progress = Optional.ofNullable(data.get("progress", float.class))
+                    .orElse(BossBar.MAX_PROGRESS);
+
+                BossBar.Color color = Optional.ofNullable(data.get("color", BossBar.Color.class))
+                    .orElse(BossBar.Color.RED);
+
+                BossBar.Overlay overlay = Optional.ofNullable(data.get("overlay", BossBar.Overlay.class))
+                    .orElse(BossBar.Overlay.PROGRESS);
+
+                yield new BossBarNotification(message, progress, color, overlay);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #86.
Tested on localhost.
An example boss bar configuration looks like this:
```
type: BOSS_BAR
message: '&dCombat ends in &f{TIME}'
progress: 1.0
color: RED
overlay: PROGRESS
```
