### PR TITLE
GH-207 Refactor Config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We expect all contributors to follow our [code of conduct](CODE_OF_CONDUCT.md).
 
 If you find an issue with the plugin, please report it in
 the [Issues tab](https://github.com/EternalCodeTeam/EternalCombat/issues). Please provide as much information as
-possible, including the version of Minecraft and the plugin you are using, as well as any error messages or logs.
+possible, including the version of Minecraft and the plugin you are using, as well as any error messagesSettings or logs.
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ more information on how to contribute and our [code of conduct](./.github/CODE_O
 
 If you find an issue with the plugin, please report it in
 the [Issues tab](https://github.com/EternalCodeTeam/EternalCombat/issues). Please provide as much information as
-possible, including the version of Minecraft and the plugin you are using, as well as any error messages or logs
+possible, including the version of Minecraft and the plugin you are using, as well as any error messagesSettings or logs

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -134,8 +134,8 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
         NotificationAnnouncer notificationAnnouncer = new NotificationAnnouncer(this.audienceProvider, this.pluginConfig, miniMessage);
 
         this.liteCommands = LiteBukkitFactory.builder(FALLBACK_PREFIX, this, server)
-            .message(LiteBukkitMessages.PLAYER_NOT_FOUND, this.pluginConfig.messages.playerNotFound)
-            .message(LiteBukkitMessages.PLAYER_ONLY, this.pluginConfig.messages.admin.onlyForPlayers)
+            .message(LiteBukkitMessages.PLAYER_NOT_FOUND, this.pluginConfig.messagesSettings.playerNotFound)
+            .message(LiteBukkitMessages.PLAYER_ONLY, this.pluginConfig.messagesSettings.admin.onlyForPlayers)
 
             .invalidUsage(new InvalidUsageHandlerImpl(this.pluginConfig, notificationAnnouncer))
             .missingPermission(new MissingPermissionHandlerImpl(this.pluginConfig, notificationAnnouncer))

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/border/BorderSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/border/BorderSettings.java
@@ -11,10 +11,18 @@ public class BorderSettings extends OkaeriConfig {
     @Comment("# Border view distance in blocks")
     public double distance = 6.5;
 
-    @Comment("# Border block animation settings")
+    @Comment({
+        " ",
+        "# Border block animation settings",
+        "# Configure the block animation that appears during combat."
+    })
     public BlockSettings block = new BlockSettings();
 
-    @Comment("# Border particle animation settings")
+    @Comment({
+        " ",
+        "# Border particle animation settings",
+        "# Configure the particle animation that appears during combat."
+    })
     public ParticleSettings particle = new ParticleSettings();
 
     public Duration indexRefreshDelay() {

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/bridge/BridgeService.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/bridge/BridgeService.java
@@ -30,9 +30,10 @@ public class BridgeService {
 
     public void init(FightManager fightManager, Server server) {
         this.initialize("WorldGuard",
-            () -> this.regionProvider = new WorldGuardRegionProvider(this.pluginConfig.settings.blockedRegions, this.pluginConfig),
+            () -> this.regionProvider = new WorldGuardRegionProvider(this.pluginConfig.regions.blockedRegions,
+                this.pluginConfig),
             () -> {
-                this.regionProvider = new DefaultRegionProvider(this.pluginConfig.settings.restrictedRegionRadius);
+                this.regionProvider = new DefaultRegionProvider(this.pluginConfig.regions.restrictedRegionRadius);
 
                 this.logger.warning("WorldGuard is not installed, set to default region provider.");
             });

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/AdminSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/AdminSettings.java
@@ -1,0 +1,20 @@
+package com.eternalcode.combat.config.implementation;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+
+public class AdminSettings extends OkaeriConfig {
+    @Comment({
+        "# Exclude server administrators from combat tagging and being tagged.",
+        "# Set to 'true' to prevent admins from being tagged or tagging others.",
+        "# Set to 'false' to allow admins to participate in combat."
+    })
+    public boolean excludeAdminsFromCombat = false;
+
+    @Comment({
+        "# Exclude players in creative mode from combat tagging and being tagged.",
+        "# Set to 'true' to prevent creative mode players from being tagged or tagging others.",
+        "# Set to 'false' to allow creative mode players to participate in combat."
+    })
+    public boolean excludeCreativePlayersFromCombat = false;
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/BlockPlacementSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/BlockPlacementSettings.java
@@ -1,0 +1,43 @@
+package com.eternalcode.combat.config.implementation;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.util.List;
+import org.bukkit.Material;
+
+public class BlockPlacementSettings extends OkaeriConfig {
+    @Comment({
+        "# Prevent players from placing blocks during combat.",
+        "# Set to 'true' to block block placement while in combat."
+    })
+    public boolean disableBlockPlacing = true;
+
+    @Comment({
+        "# Restrict block placement above or below a specific Y coordinate.",
+        "# Available modes: ABOVE (blocks cannot be placed above the Y coordinate), BELOW (blocks cannot be placed below the Y coordinate)."
+    })
+    public BlockPlacingMode blockPlacementMode = BlockPlacingMode.ABOVE;
+
+    @Comment({
+        "# Custom name for the block placement mode used in messages.",
+        "# This name will be displayed in notifications related to block placement restrictions."
+    })
+    public String blockPlacementModeDisplayName = "above";
+
+    @Comment({
+        "# Define the Y coordinate for block placement restrictions.",
+        "# This value is relative to the selected block placement mode (ABOVE or BELOW)."
+    })
+    public int blockPlacementYCoordinate = 40;
+    @Comment({
+        "# Restrict the placement of specific blocks during combat.",
+        "# Add blocks to this list to prevent their placement. Leave the list empty to block all blocks.",
+        "# Note: This feature requires 'disableBlockPlacing' to be enabled."
+    })
+    public List<Material> restrictedBlockTypes = List.of();
+
+    public enum BlockPlacingMode {
+        ABOVE,
+        BELOW
+    }
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/CombatSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/CombatSettings.java
@@ -1,0 +1,75 @@
+package com.eternalcode.combat.config.implementation;
+
+import com.eternalcode.combat.WhitelistBlacklistMode;
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.util.List;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+public class CombatSettings extends OkaeriConfig {
+    @Comment({
+        "# Automatically release the attacker from combat when the victim dies.",
+        "# Set to 'true' to enable this feature, or 'false' to keep the attacker in combat."
+    })
+    public boolean releaseAttackerOnVictimDeath = true;
+
+    @Comment({
+        "# Disable the use of elytra during combat.",
+        "# Set to 'true' to prevent players from using elytra while in combat."
+    })
+    public boolean disableElytraUsage = true;
+
+    @Comment({
+        "# Disable the use of elytra when a player takes damage.",
+        "# Set to 'true' to disable elytra usage upon taking damage, even when the player is mid-air."
+    })
+    public boolean disableElytraOnDamage = true;
+
+    @Comment({
+        "# Prevent players from flying during combat.",
+        "# Flying players will fall to the ground if this is enabled."
+    })
+    public boolean disableFlying = true;
+
+    @Comment({
+        "# Prevent players from opening their inventory during combat.",
+        "# Set to 'true' to block inventory access while in combat."
+    })
+    public boolean disableInventoryAccess = false;
+
+    @Comment({
+        "# Enable or disable combat logging for damage caused by non-player entities.",
+        "# Set to 'true' to log damage from non-player sources, or 'false' to disable this feature."
+    })
+    public boolean enableDamageCauseLogging = false;
+
+    @Comment({
+        "# Set the mode for logging damage causes.",
+        "# Available modes: WHITELIST (only listed causes are logged), BLACKLIST (all causes except listed ones are logged)."
+    })
+    public WhitelistBlacklistMode damageCauseRestrictionMode = WhitelistBlacklistMode.WHITELIST;
+
+    @Comment({
+        "# List of damage causes to be logged based on the selected mode.",
+        "# In WHITELIST mode, only these causes are logged. In BLACKLIST mode, all causes except these are logged.",
+        "# For a full list of damage causes, visit: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html"
+    })
+    public List<DamageCause> loggedDamageCauses = List.of(
+        DamageCause.LAVA,
+        DamageCause.CONTACT,
+        DamageCause.FIRE,
+        DamageCause.FIRE_TICK
+    );
+
+    @Comment({
+        "# List of projectile types that do not trigger combat tagging.",
+        "# Players hit by these projectiles will not be tagged as in combat.",
+        "# For a full list of entity types, visit: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html"
+    })
+    public List<EntityType> ignoredProjectileTypes = List.of(
+        EntityType.ENDER_PEARL,
+        EntityType.EGG
+    );
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/CommandSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/CommandSettings.java
@@ -1,0 +1,26 @@
+package com.eternalcode.combat.config.implementation;
+
+import com.eternalcode.combat.WhitelistBlacklistMode;
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.util.List;
+
+public class CommandSettings extends OkaeriConfig {
+    @Comment({
+        "# Set the mode for command restrictions during combat.",
+        "# Available modes: WHITELIST (only listed commands are allowed), BLACKLIST (listed commands are blocked)."
+    })
+    public WhitelistBlacklistMode commandRestrictionMode = WhitelistBlacklistMode.BLACKLIST;
+
+    @Comment({
+        "# List of commands affected by the command restriction mode.",
+        "# In BLACKLIST mode, these commands are blocked. In WHITELIST mode, only these commands are allowed."
+    })
+    public List<String> restrictedCommands = List.of(
+        "gamemode",
+        "spawn",
+        "tp",
+        "tpa",
+        "tpaccept"
+    );
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/MessagesSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/MessagesSettings.java
@@ -1,0 +1,200 @@
+package com.eternalcode.combat.config.implementation;
+
+import com.eternalcode.multification.bukkit.notice.BukkitNotice;
+import com.eternalcode.multification.notice.Notice;
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+
+public class MessagesSettings extends OkaeriConfig {
+
+    @Comment({
+        "# Customize messages related to admin commands and notifications.",
+        "# These messages are displayed to server administrators."
+    })
+    public AdminMessages admin = new AdminMessages();
+
+    @Comment({
+        " ",
+        "# Configure the combat log notification displayed to players.",
+        "# You can use the {TIME} variable to display the remaining combat time.",
+        " ",
+        "# BossBar progress: Set to -1.0 to show the remaining combat time as a progress bar.",
+        "# BossBar colors: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Color.html",
+        "# BossBar overlays: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Overlay.html"
+    })
+    public Notice combatNotification = BukkitNotice.builder()
+        .actionBar("<bold>Combat ends in: <red>{TIME}</red></bold>")
+        .sound(Sound.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.PLAYERS, 2.0F, 1.0F)
+        .build();
+
+    @Comment({
+        "# Message displayed when a player lacks permission to execute a command.",
+        "# The {PERMISSION} placeholder is replaced with the required permission."
+    })
+    public Notice noPermission = Notice.chat(
+        "<gradient:red:dark_red>You don't have permission <dark_gray>(<gray>{PERMISSION}</gray>)</dark_gray> to perform this command!</gradient>");
+
+    @Comment({
+        "# Message displayed when a specified player is not found.",
+        "# This message is shown when a command targets a player who is not online or does not exist."
+    })
+    public Notice playerNotFound =
+        Notice.chat("<gradient:#ff0000:#ff6b6b>The specified player could not be found!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player enters combat.",
+        "# This message warns the player not to leave the server while in combat."
+    })
+    public Notice playerTagged = Notice.chat(
+        "<gradient:red:yellow>⚠ <white>You are in combat!</white> <u>Do not leave the server!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player leaves combat.",
+        "# This message informs the player that they can safely leave the server."
+    })
+    public Notice playerUntagged = Notice.chat(
+        "<gradient:#00ff00:#00b300>✌ <white>Combat ended!</white> You can now safely leave!</u></gradient>");
+
+    @Comment({
+        "# Broadcast message displayed when a player logs out during combat.",
+        "# The {PLAYER} placeholder is replaced with the player's name."
+    })
+    public Notice playerLoggedOutDuringCombat =
+        Notice.chat("<gradient:red:dark_red>⚠ <white>{PLAYER}</white> logged off during combat!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player attempts to use a disabled command during combat.",
+        "# This message informs the player that the command is prohibited while in combat."
+    })
+    public Notice commandDisabledDuringCombat = Notice.chat(
+        "<gradient:red:yellow>⚠ <white>Command blocked!</white> Cannot use this during combat!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player uses a command with incorrect arguments.",
+        "# The {USAGE} placeholder is replaced with the correct command syntax."
+    })
+    public Notice invalidCommandUsage = Notice.chat("<gray>Usage: <gradient:gold:yellow>{USAGE}</gradient>");
+
+    @Comment({
+        "# Message displayed when a player attempts to open their inventory during combat.",
+        "# This message informs the player that inventory access is blocked while in combat."
+    })
+    public Notice inventoryBlockedDuringCombat = Notice.chat(
+        "<gradient:red:dark_red>⚠ <white>Inventory access</white> is restricted during combat!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player attempts to place a block during combat.",
+        "# The {MODE} placeholder is replaced with the block placement mode (ABOVE/BELOW).",
+        "# The {Y} placeholder is replaced with the Y coordinate set in the config."
+    })
+    public Notice blockPlacingBlockedDuringCombat =
+        Notice.chat("<gradient:red:yellow>⚠ Block placement <white>{MODE} Y:{Y}</white> is restricted!</gradient>");
+
+    @Comment({
+        "# Message displayed when a player attempts to enter a restricted region during combat.",
+        "# This message informs the player that they cannot enter the region while in combat."
+    })
+    public Notice cantEnterOnRegion = Notice.chat(
+        "<gradient:red:dark_red>⚠ Restricted area!</gradient> <white>Cannot enter during combat!</white>");
+
+    public static class AdminMessages extends OkaeriConfig {
+        @Comment({
+            "# Message displayed when the console attempts to use a player-only command.",
+            "# This message informs the console that the command is not available for non-players."
+        })
+        public Notice onlyForPlayers =
+            Notice.chat("<gradient:red:dark_red>❌ This command is player-only!</gradient>");
+
+        @Comment({
+            "# Message displayed to an admin when they tag a player.",
+            "# The {PLAYER} placeholder is replaced with the tagged player's name."
+        })
+        public Notice adminTagPlayer =
+            Notice.chat("<gradient:#00b3ff:#0066ff>⚔ <gray>Tagged player:</gray> <white>{PLAYER}</white></gradient>");
+
+        @Comment({
+            "# Message displayed when an admin tags multiple players.",
+            "# The {FIRST_PLAYER} and {SECOND_PLAYER} placeholders are replaced with the players' names."
+        })
+        public Notice adminTagMultiplePlayers = Notice.chat(
+            "<gradient:#00b3ff:#0066ff>⚔ <gray>Tagged:</gray> <white>{FIRST_PLAYER}</white> <gray>and</gray> <white>{SECOND_PLAYER}</white></gradient>");
+
+        @Comment({
+            "# Message displayed to an admin when they remove a player from combat.",
+            "# The {PLAYER} placeholder is replaced with the player's name."
+        })
+        public Notice adminUntagPlayer = Notice.chat(
+            "<gradient:#00ff88:#00b300>✌ <gray>Removed</gray> <white>{PLAYER}</white> <gray>from combat</gray></gradient>");
+
+        @Comment({
+            "# Message displayed when an admin attempts to untag a player who is not in combat.",
+            "# This message informs the admin that the player is not currently in combat."
+        })
+        public Notice adminPlayerNotInCombat =
+            Notice.chat("<gradient:red:dark_red>❌ <white>{PLAYER}</white> is not in combat!</gradient>");
+
+        @Comment({
+            "# Message displayed when a player is in combat.",
+            "# The {PLAYER} placeholder is replaced with the player's name."
+        })
+        public Notice playerInCombat =
+            Notice.chat("<gradient:#ff6666:#ff0000>⚔ <white>{PLAYER}</white> <gray>is in combat!</gray></gradient>");
+
+        @Comment({
+            "# Message displayed when a player is not in combat.",
+            "# The {PLAYER} placeholder is replaced with the player's name."
+        })
+        public Notice playerNotInCombat =
+            Notice.chat("<gradient:#00ff00:#00b300>✌ <white>{PLAYER}</white> <gray>is safe</gray></gradient>");
+
+        @Comment({
+            "# Message displayed when an admin attempts to tag themselves.",
+            "# This message informs the admin that they cannot tag themselves."
+        })
+        public Notice adminCannotTagSelf = Notice.chat("<gradient:red:dark_red>❌ Cannot tag yourself!</gradient>");
+
+        @Comment({
+            "# Message displayed when an admin disables combat tagging for themselves.",
+            "# The {TIME} placeholder is replaced with the remaining fight time."
+        })
+        public Notice adminTagOutSelf = Notice.chat(
+            "<gradient:#00b3ff:#0066ff>🛡 <gray>Self-protection active for</gray> <white>{TIME}</white></gradient>");
+
+        @Comment({
+            "# Message displayed when an admin disables combat tagging for another player.",
+            "# The {PLAYER} placeholder is replaced with the player's name.",
+            "# The {TIME} placeholder is replaced with the remaining fight time."
+        })
+        public Notice adminTagOut = Notice.chat(
+            "<gradient:#00b3ff:#0066ff>🛡 <gray>Protected</gray> <white>{PLAYER}</white> <gray>for</gray> <white>{TIME}</white></gradient>");
+
+        @Comment({
+            "# Message displayed to a player when their combat tagging is disabled.",
+            "# The {TIME} placeholder is replaced with the remaining fight time."
+        })
+        public Notice playerTagOut = Notice.chat(
+            "<gradient:#00ff88:#00b300>🛡 <gray>Protection active for</gray> <white>{TIME}</white></gradient>");
+
+        @Comment({
+            "# Message displayed when an admin reenables combat tagging for a player.",
+            "# The {PLAYER} placeholder is replaced with the player's name."
+        })
+        public Notice adminTagOutOff = Notice.chat(
+            "<gradient:#00ff88:#00b300>✌ <gray>Re-enabled tagging for</gray> <white>{PLAYER}</white></gradient>");
+
+        @Comment({
+            "# Message displayed to a player when their combat tagging is reenabled.",
+            "# This message informs the player that they can now be tagged again."
+        })
+        public Notice playerTagOutOff = Notice.chat("");
+
+        @Comment({
+            "# Message displayed when an admin attempts to tag a player who has tag-out enabled.",
+            "# This message informs the admin that the player cannot be tagged at this time."
+        })
+        public Notice adminTagOutCanceled =
+            Notice.chat("<gradient:red:dark_red>❌ Player has tag-out protection!</gradient>");
+    }
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -1,23 +1,13 @@
 package com.eternalcode.combat.config.implementation;
 
-import com.eternalcode.combat.WhitelistBlacklistMode;
 import com.eternalcode.combat.border.BorderSettings;
 import com.eternalcode.combat.fight.drop.DropSettings;
 import com.eternalcode.combat.fight.effect.FightEffectSettings;
 import com.eternalcode.combat.fight.knockback.KnockbackSettings;
 import com.eternalcode.combat.fight.pearl.FightPearlSettings;
-import com.eternalcode.multification.bukkit.notice.BukkitNotice;
-import com.eternalcode.multification.notice.Notice;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
-import org.bukkit.Material;
-import org.bukkit.Sound;
-import org.bukkit.SoundCategory;
-import org.bukkit.entity.EntityType;
-import org.bukkit.event.entity.EntityDamageEvent;
-
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 
 public class PluginConfig extends OkaeriConfig {
@@ -32,6 +22,7 @@ public class PluginConfig extends OkaeriConfig {
     @Comment(" ")
 
     @Comment({
+        " ",
         "# Settings for the plugin.",
         "# Modify these to customize the plugin's behavior."
     })
@@ -58,16 +49,63 @@ public class PluginConfig extends OkaeriConfig {
     })
     public DropSettings drop = new DropSettings();
 
+    @Comment({
+        " ",
+        "# Settings related to knockback during combat.",
+        "# Configure knockback settings and behaviors for players in combat."
+    })
     public KnockbackSettings knockback = new KnockbackSettings();
 
     @Comment({
-        "",
+        " ",
         "# Border Settings",
+        "# Configure the border that appears during combat.",
     })
     public BorderSettings border = new BorderSettings();
 
-    public static class Settings extends OkaeriConfig {
+    @Comment({
+        " ",
+        "# Settings related to block placement during combat.",
+        "# Configure restrictions and behaviors for block placement while players are in combat."
+    })
+    public BlockPlacementSettings blockPlacement = new BlockPlacementSettings();
 
+    @Comment({
+        " ",
+        "# Settings related to commands during combat.",
+        "# Configure command restrictions and behaviors for players in combat."
+    })
+    public CommandSettings commands = new CommandSettings();
+
+    @Comment({
+        " ",
+        "# Settings related to the plugin's admin commands and features.",
+        "# Configure admin-specific settings and behaviors for the plugin."
+    })
+    public AdminSettings admin = new AdminSettings();
+
+    @Comment({
+        " ",
+        "# Settings related to regions.",
+        "# Configure region-specific settings and behaviors for combat."
+    })
+    public RegionSettings regions = new RegionSettings();
+
+    @Comment({
+        " ",
+        "# Settings related to combat and player tagging.",
+        "# Configure combat rules, and behaviors for player tagging."
+    })
+    public CombatSettings combat = new CombatSettings();
+
+    @Comment({
+        " ",
+        "# Customize the messages displayed by the plugin.",
+        "# Modify these to change the text and formatting of notifications and alerts."
+    })
+    public MessagesSettings messagesSettings = new MessagesSettings();
+
+    public static class Settings extends OkaeriConfig {
         @Comment({
             "# Notify players about new plugin updates when they join the server.",
             "# Set to 'true' to enable update notifications, or 'false' to disable them."
@@ -87,333 +125,5 @@ public class PluginConfig extends OkaeriConfig {
         public List<String> ignoredWorlds = List.of(
             "your_world"
         );
-
-        @Comment({
-            "# List of regions where combat is restricted.",
-            "# Players in these regions will not be able to engage in combat."
-        })
-        public List<String> blockedRegions = Collections.singletonList("your_region");
-
-        @Comment({
-            "# Prevent players from entering regions where PVP is disabled by WorldGuard.",
-            "# Set to 'true' to enforce this restriction, or 'false' to allow PVP in all regions."
-        })
-        public boolean preventPvpInRegions = true;
-
-        @Comment({
-            "# Define the radius of restricted regions if WorldGuard is not used.",
-            "# This setting is based on the default spawn region."
-        })
-        public int restrictedRegionRadius = 10;
-
-        @Comment({
-            "# Automatically release the attacker from combat when the victim dies.",
-            "# Set to 'true' to enable this feature, or 'false' to keep the attacker in combat."
-        })
-        public boolean releaseAttackerOnVictimDeath = true;
-
-        @Comment({
-            "# Exclude server administrators from combat tagging and being tagged.",
-            "# Set to 'true' to prevent admins from being tagged or tagging others.",
-            "# Set to 'false' to allow admins to participate in combat."
-        })
-        public boolean excludeAdminsFromCombat = false;
-
-        @Comment({
-            "# Exclude players in creative mode from combat tagging and being tagged.",
-            "# Set to 'true' to prevent creative mode players from being tagged or tagging others.",
-            "# Set to 'false' to allow creative mode players to participate in combat."
-        })
-        public boolean excludeCreativePlayersFromCombat = false;
-
-        @Comment({
-            "# Set the mode for command restrictions during combat.",
-            "# Available modes: WHITELIST (only listed commands are allowed), BLACKLIST (listed commands are blocked)."
-        })
-        public WhitelistBlacklistMode commandRestrictionMode = WhitelistBlacklistMode.BLACKLIST;
-
-        @Comment({
-            "# List of commands affected by the command restriction mode.",
-            "# In BLACKLIST mode, these commands are blocked. In WHITELIST mode, only these commands are allowed."
-        })
-        public List<String> restrictedCommands = List.of(
-            "gamemode",
-            "spawn",
-            "tp",
-            "tpa",
-            "tpaccept"
-        );
-
-        @Comment({
-            "# Disable the use of elytra during combat.",
-            "# Set to 'true' to prevent players from using elytra while in combat."
-        })
-        public boolean disableElytraUsage = true;
-
-        @Comment({
-            "# Disable the use of elytra when a player takes damage.",
-            "# Set to 'true' to disable elytra usage upon taking damage, even when the player is mid-air."
-        })
-        public boolean disableElytraOnDamage = true;
-
-        @Comment({
-            "# Prevent players from flying during combat.",
-            "# Flying players will fall to the ground if this is enabled."
-        })
-        public boolean disableFlying = true;
-
-        @Comment({
-            "# Prevent players from opening their inventory during combat.",
-            "# Set to 'true' to block inventory access while in combat."
-        })
-        public boolean disableInventoryAccess = false;
-
-        @Comment({
-            "# Prevent players from placing blocks during combat.",
-            "# Set to 'true' to block block placement while in combat."
-        })
-        public boolean disableBlockPlacing = true;
-
-        @Comment({
-            "# Restrict block placement above or below a specific Y coordinate.",
-            "# Available modes: ABOVE (blocks cannot be placed above the Y coordinate), BELOW (blocks cannot be placed below the Y coordinate)."
-        })
-        public BlockPlacingMode blockPlacementMode = BlockPlacingMode.ABOVE;
-
-        @Comment({
-            "# Custom name for the block placement mode used in messages.",
-            "# This name will be displayed in notifications related to block placement restrictions."
-        })
-        public String blockPlacementModeDisplayName = "above";
-
-        @Comment({
-            "# Define the Y coordinate for block placement restrictions.",
-            "# This value is relative to the selected block placement mode (ABOVE or BELOW)."
-        })
-        public int blockPlacementYCoordinate = 40;
-
-        public enum BlockPlacingMode {
-            ABOVE,
-            BELOW
-        }
-
-        @Comment({
-            "# Restrict the placement of specific blocks during combat.",
-            "# Add blocks to this list to prevent their placement. Leave the list empty to block all blocks.",
-            "# Note: This feature requires 'disableBlockPlacing' to be enabled."
-        })
-        public List<Material> restrictedBlockTypes = List.of();
-
-        @Comment({
-            "# Enable or disable combat logging for damage caused by non-player entities.",
-            "# Set to 'true' to log damage from non-player sources, or 'false' to disable this feature."
-        })
-        public boolean enableDamageCauseLogging = false;
-
-        @Comment({
-            "# Set the mode for logging damage causes.",
-            "# Available modes: WHITELIST (only listed causes are logged), BLACKLIST (all causes except listed ones are logged)."
-        })
-        public WhitelistBlacklistMode damageCauseRestrictionMode = WhitelistBlacklistMode.WHITELIST;
-
-        @Comment({
-            "# List of damage causes to be logged based on the selected mode.",
-            "# In WHITELIST mode, only these causes are logged. In BLACKLIST mode, all causes except these are logged.",
-            "# For a full list of damage causes, visit: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html"
-        })
-        public List<EntityDamageEvent.DamageCause> loggedDamageCauses = List.of(
-            EntityDamageEvent.DamageCause.LAVA,
-            EntityDamageEvent.DamageCause.CONTACT,
-            EntityDamageEvent.DamageCause.FIRE,
-            EntityDamageEvent.DamageCause.FIRE_TICK
-        );
-
-        @Comment({
-            "# List of projectile types that do not trigger combat tagging.",
-            "# Players hit by these projectiles will not be tagged as in combat.",
-            "# For a full list of entity types, visit: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html"
-        })
-        public List<EntityType> ignoredProjectileTypes = List.of(
-            EntityType.ENDER_PEARL,
-            EntityType.EGG
-        );
-    }
-
-    @Comment({
-        " ",
-        "# Customize the messages displayed by the plugin.",
-        "# Modify these to change the text and formatting of notifications and alerts."
-    })
-    public Messages messages = new Messages();
-
-    public static class Messages extends OkaeriConfig {
-
-        @Comment({
-            "# Customize messages related to admin commands and notifications.",
-            "# These messages are displayed to server administrators."
-        })
-        public AdminMessages admin = new AdminMessages();
-
-        @Comment({
-            " ",
-            "# Configure the combat log notification displayed to players.",
-            "# You can use the {TIME} variable to display the remaining combat time.",
-            " ",
-            "# BossBar progress: Set to -1.0 to show the remaining combat time as a progress bar.",
-            "# BossBar colors: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Color.html",
-            "# BossBar overlays: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Overlay.html"
-        })
-        public Notice combatNotification = BukkitNotice.builder()
-            .actionBar("<bold>Combat ends in: <red>{TIME}</red></bold>")
-            .sound(Sound.ENTITY_EXPERIENCE_ORB_PICKUP, SoundCategory.PLAYERS, 2.0F, 1.0F)
-            .build();
-
-        @Comment({
-            "# Message displayed when a player lacks permission to execute a command.",
-            "# The {PERMISSION} placeholder is replaced with the required permission."
-        })
-        public Notice noPermission = Notice.chat("<gradient:red:dark_red>You don't have permission <dark_gray>(<gray>{PERMISSION}</gray>)</dark_gray> to perform this command!</gradient>");
-
-        @Comment({
-            "# Message displayed when a specified player is not found.",
-            "# This message is shown when a command targets a player who is not online or does not exist."
-        })
-        public Notice playerNotFound = Notice.chat("<gradient:#ff0000:#ff6b6b>The specified player could not be found!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player enters combat.",
-            "# This message warns the player not to leave the server while in combat."
-        })
-        public Notice playerTagged = Notice.chat("<gradient:red:yellow>⚠ <white>You are in combat!</white> <u>Do not leave the server!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player leaves combat.",
-            "# This message informs the player that they can safely leave the server."
-        })
-        public Notice playerUntagged = Notice.chat("<gradient:#00ff00:#00b300>✌ <white>Combat ended!</white> You can now safely leave!</u></gradient>");
-
-        @Comment({
-            "# Broadcast message displayed when a player logs out during combat.",
-            "# The {PLAYER} placeholder is replaced with the player's name."
-        })
-        public Notice playerLoggedOutDuringCombat = Notice.chat("<gradient:red:dark_red>⚠ <white>{PLAYER}</white> logged off during combat!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player attempts to use a disabled command during combat.",
-            "# This message informs the player that the command is prohibited while in combat."
-        })
-        public Notice commandDisabledDuringCombat = Notice.chat("<gradient:red:yellow>⚠ <white>Command blocked!</white> Cannot use this during combat!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player uses a command with incorrect arguments.",
-            "# The {USAGE} placeholder is replaced with the correct command syntax."
-        })
-        public Notice invalidCommandUsage = Notice.chat("<gray>Usage: <gradient:gold:yellow>{USAGE}</gradient>");
-
-        @Comment({
-            "# Message displayed when a player attempts to open their inventory during combat.",
-            "# This message informs the player that inventory access is blocked while in combat."
-        })
-        public Notice inventoryBlockedDuringCombat = Notice.chat("<gradient:red:dark_red>⚠ <white>Inventory access</white> is restricted during combat!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player attempts to place a block during combat.",
-            "# The {MODE} placeholder is replaced with the block placement mode (ABOVE/BELOW).",
-            "# The {Y} placeholder is replaced with the Y coordinate set in the config."
-        })
-        public Notice blockPlacingBlockedDuringCombat = Notice.chat("<gradient:red:yellow>⚠ Block placement <white>{MODE} Y:{Y}</white> is restricted!</gradient>");
-
-        @Comment({
-            "# Message displayed when a player attempts to enter a restricted region during combat.",
-            "# This message informs the player that they cannot enter the region while in combat."
-        })
-        public Notice cantEnterOnRegion = Notice.chat("<gradient:red:dark_red>⚠ Restricted area!</gradient> <white>Cannot enter during combat!</white>");
-
-        public static class AdminMessages extends OkaeriConfig {
-            @Comment({
-                "# Message displayed when the console attempts to use a player-only command.",
-                "# This message informs the console that the command is not available for non-players."
-            })
-            public Notice onlyForPlayers = Notice.chat("<gradient:red:dark_red>❌ This command is player-only!</gradient>");
-
-            @Comment({
-                "# Message displayed to an admin when they tag a player.",
-                "# The {PLAYER} placeholder is replaced with the tagged player's name."
-            })
-            public Notice adminTagPlayer = Notice.chat("<gradient:#00b3ff:#0066ff>⚔ <gray>Tagged player:</gray> <white>{PLAYER}</white></gradient>");
-
-            @Comment({
-                "# Message displayed when an admin tags multiple players.",
-                "# The {FIRST_PLAYER} and {SECOND_PLAYER} placeholders are replaced with the players' names."
-            })
-            public Notice adminTagMultiplePlayers = Notice.chat("<gradient:#00b3ff:#0066ff>⚔ <gray>Tagged:</gray> <white>{FIRST_PLAYER}</white> <gray>and</gray> <white>{SECOND_PLAYER}</white></gradient>");
-
-            @Comment({
-                "# Message displayed to an admin when they remove a player from combat.",
-                "# The {PLAYER} placeholder is replaced with the player's name."
-            })
-            public Notice adminUntagPlayer = Notice.chat("<gradient:#00ff88:#00b300>✌ <gray>Removed</gray> <white>{PLAYER}</white> <gray>from combat</gray></gradient>");
-
-            @Comment({
-                "# Message displayed when an admin attempts to untag a player who is not in combat.",
-                "# This message informs the admin that the player is not currently in combat."
-            })
-            public Notice adminPlayerNotInCombat = Notice.chat("<gradient:red:dark_red>❌ <white>{PLAYER}</white> is not in combat!</gradient>");
-
-            @Comment({
-                "# Message displayed when a player is in combat.",
-                "# The {PLAYER} placeholder is replaced with the player's name."
-            })
-            public Notice playerInCombat = Notice.chat("<gradient:#ff6666:#ff0000>⚔ <white>{PLAYER}</white> <gray>is in combat!</gray></gradient>");
-
-            @Comment({
-                "# Message displayed when a player is not in combat.",
-                "# The {PLAYER} placeholder is replaced with the player's name."
-            })
-            public Notice playerNotInCombat = Notice.chat("<gradient:#00ff00:#00b300>✌ <white>{PLAYER}</white> <gray>is safe</gray></gradient>");
-
-            @Comment({
-                "# Message displayed when an admin attempts to tag themselves.",
-                "# This message informs the admin that they cannot tag themselves."
-            })
-            public Notice adminCannotTagSelf = Notice.chat("<gradient:red:dark_red>❌ Cannot tag yourself!</gradient>");
-
-            @Comment({
-                "# Message displayed when an admin disables combat tagging for themselves.",
-                "# The {TIME} placeholder is replaced with the remaining fight time."
-            })
-            public Notice adminTagOutSelf = Notice.chat("<gradient:#00b3ff:#0066ff>🛡 <gray>Self-protection active for</gray> <white>{TIME}</white></gradient>");
-
-            @Comment({
-                "# Message displayed when an admin disables combat tagging for another player.",
-                "# The {PLAYER} placeholder is replaced with the player's name.",
-                "# The {TIME} placeholder is replaced with the remaining fight time."
-            })
-            public Notice adminTagOut = Notice.chat("<gradient:#00b3ff:#0066ff>🛡 <gray>Protected</gray> <white>{PLAYER}</white> <gray>for</gray> <white>{TIME}</white></gradient>");
-
-            @Comment({
-                "# Message displayed to a player when their combat tagging is disabled.",
-                "# The {TIME} placeholder is replaced with the remaining fight time."
-            })
-            public Notice playerTagOut = Notice.chat("<gradient:#00ff88:#00b300>🛡 <gray>Protection active for</gray> <white>{TIME}</white></gradient>");
-
-            @Comment({
-                "# Message displayed when an admin reenables combat tagging for a player.",
-                "# The {PLAYER} placeholder is replaced with the player's name."
-            })
-            public Notice adminTagOutOff = Notice.chat("<gradient:#00ff88:#00b300>✌ <gray>Re-enabled tagging for</gray> <white>{PLAYER}</white></gradient>");
-
-            @Comment({
-                "# Message displayed to a player when their combat tagging is reenabled.",
-                "# This message informs the player that they can now be tagged again."
-            })
-            public Notice playerTagOutOff = Notice.chat("");
-
-            @Comment({
-                "# Message displayed when an admin attempts to tag a player who has tag-out enabled.",
-                "# This message informs the admin that the player cannot be tagged at this time."
-            })
-            public Notice adminTagOutCanceled = Notice.chat("<gradient:red:dark_red>❌ Player has tag-out protection!</gradient>");
-        }
     }
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/RegionSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/RegionSettings.java
@@ -1,0 +1,26 @@
+package com.eternalcode.combat.config.implementation;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.util.Collections;
+import java.util.List;
+
+public class RegionSettings extends OkaeriConfig {
+    @Comment({
+        "# List of regions where combat is restricted.",
+        "# Players in these regions will not be able to engage in combat."
+    })
+    public List<String> blockedRegions = Collections.singletonList("your_region");
+
+    @Comment({
+        "# Prevent players from entering regions where PVP is disabled by WorldGuard.",
+        "# Set to 'true' to enforce this restriction, or 'false' to allow PVP in all regions."
+    })
+    public boolean preventPvpInRegions = true;
+
+    @Comment({
+        "# Define the radius of restricted regions if WorldGuard is not used.",
+        "# This setting is based on the default spawn region."
+    })
+    public int restrictedRegionRadius = 10;
+}

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
@@ -1,5 +1,6 @@
 package com.eternalcode.combat.fight;
 
+import com.eternalcode.combat.config.implementation.MessagesSettings;
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.combat.fight.event.CancelTagReason;
 import com.eternalcode.combat.fight.event.CauseOfTag;
@@ -39,8 +40,8 @@ public class FightTagCommand {
 
         this.announcer.create()
             .notice(this.fightManager.isInCombat(targetUniqueId)
-                ? this.config.messages.admin.playerInCombat
-                : this.config.messages.admin.playerNotInCombat
+                ? this.config.messagesSettings.admin.playerInCombat
+                : this.config.messagesSettings.admin.playerNotInCombat
             )
             .placeholder("{PLAYER}", target.getName())
             .viewer(sender)
@@ -60,13 +61,13 @@ public class FightTagCommand {
         if (event.isCancelled()) {
             CancelTagReason cancelReason = event.getCancelReason();
 
-            this.tagoutReasonHandler(sender, cancelReason, this.config.messages);
+            this.tagoutReasonHandler(sender, cancelReason, this.config.messagesSettings);
 
             return;
         }
 
         this.announcer.create()
-            .notice(this.config.messages.admin.adminTagPlayer)
+            .notice(this.config.messagesSettings.admin.adminTagPlayer)
             .placeholder("{PLAYER}", target.getName())
             .viewer(sender)
             .send();
@@ -77,12 +78,12 @@ public class FightTagCommand {
     @Permission("eternalcombat.tag")
     void tagMultiple(@Context CommandSender sender, @Arg Player firstTarget, @Arg Player secondTarget) {
         Duration combatTime = this.config.settings.combatTimerDuration;
-        PluginConfig.Messages messages = this.config.messages;
+        MessagesSettings messagesSettings = this.config.messagesSettings;
 
         if (sender.equals(firstTarget) || sender.equals(secondTarget)) {
 
             this.announcer.create()
-                .notice(messages.admin.adminCannotTagSelf)
+                .notice(messagesSettings.admin.adminCannotTagSelf)
                 .viewer(sender)
                 .send();
 
@@ -95,7 +96,7 @@ public class FightTagCommand {
         if (firstTagEvent.isCancelled()) {
             CancelTagReason cancelReason = firstTagEvent.getCancelReason();
 
-            this.tagoutReasonHandler(sender, cancelReason, messages);
+            this.tagoutReasonHandler(sender, cancelReason, messagesSettings);
 
             return;
         }
@@ -103,7 +104,7 @@ public class FightTagCommand {
         if (secondTagEvent.isCancelled()) {
             CancelTagReason cancelReason = secondTagEvent.getCancelReason();
 
-            this.tagoutReasonHandler(sender, cancelReason, messages);
+            this.tagoutReasonHandler(sender, cancelReason, messagesSettings);
 
             return;
         }
@@ -113,7 +114,7 @@ public class FightTagCommand {
         }
 
         this.announcer.create()
-            .notice(messages.admin.adminTagMultiplePlayers)
+            .notice(messagesSettings.admin.adminTagMultiplePlayers)
             .placeholder("{FIRST_PLAYER}", firstTarget.getName())
             .placeholder("{SECOND_PLAYER}", secondTarget.getName())
             .viewer(sender)
@@ -129,7 +130,7 @@ public class FightTagCommand {
         if (!this.fightManager.isInCombat(targetUniqueId)) {
             this.announcer.create()
                 .viewer(sender)
-                .notice(this.config.messages.admin.adminPlayerNotInCombat)
+                .notice(this.config.messagesSettings.admin.adminPlayerNotInCombat)
                 .send();
             return;
         }
@@ -141,16 +142,16 @@ public class FightTagCommand {
 
 
         this.announcer.create()
-            .notice(this.config.messages.admin.adminUntagPlayer)
+            .notice(this.config.messagesSettings.admin.adminUntagPlayer)
             .placeholder("{PLAYER}", target.getName())
             .viewer(sender)
             .send();
     }
 
-    private void tagoutReasonHandler(CommandSender sender, CancelTagReason cancelReason, PluginConfig.Messages messages) {
+    private void tagoutReasonHandler(CommandSender sender, CancelTagReason cancelReason, MessagesSettings messagesSettings) {
         if (cancelReason == CancelTagReason.TAGOUT) {
             this.announcer.create()
-                .notice(messages.admin.adminTagOutCanceled)
+                .notice(messagesSettings.admin.adminTagOutCanceled)
                 .viewer(sender)
                 .send();
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTask.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTask.java
@@ -44,7 +44,7 @@ public class FightTask implements Runnable {
 
             this.announcer.create()
                 .player(player.getUniqueId())
-                .notice(this.config.messages.combatNotification)
+                .notice(this.config.messagesSettings.combatNotification)
                 .placeholder("{TIME}", DurationUtil.format(remaining))
                 .send();
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightActionBlockerController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightActionBlockerController.java
@@ -2,6 +2,7 @@ package com.eternalcode.combat.fight.controller;
 
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.combat.WhitelistBlacklistMode;
+import com.eternalcode.combat.config.implementation.BlockPlacementSettings;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.fight.event.FightUntagEvent;
 import com.eternalcode.combat.notification.NotificationAnnouncer;
@@ -38,7 +39,7 @@ public class FightActionBlockerController implements Listener {
 
     @EventHandler
     void onPlace(BlockPlaceEvent event) {
-        if (!this.config.settings.disableBlockPlacing) {
+        if (!this.config.blockPlacement.disableBlockPlacing) {
             return;
         }
 
@@ -52,7 +53,7 @@ public class FightActionBlockerController implements Listener {
         Block block = event.getBlock();
         int level = block.getY();
 
-        List<Material> specificBlocksToPreventPlacing = this.config.settings.restrictedBlockTypes;
+        List<Material> specificBlocksToPreventPlacing = this.config.blockPlacement.restrictedBlockTypes;
 
         boolean isPlacementBlocked = this.isPlacementBlocked(level);
 
@@ -60,9 +61,9 @@ public class FightActionBlockerController implements Listener {
             event.setCancelled(true);
             this.announcer.create()
                 .player(uniqueId)
-                .notice(this.config.messages.blockPlacingBlockedDuringCombat)
-                .placeholder("{Y}", String.valueOf(this.config.settings.blockPlacementYCoordinate))
-                .placeholder("{MODE}", this.config.settings.blockPlacementModeDisplayName)
+                .notice(this.config.messagesSettings.blockPlacingBlockedDuringCombat)
+                .placeholder("{Y}", String.valueOf(this.config.blockPlacement.blockPlacementYCoordinate))
+                .placeholder("{MODE}", this.config.blockPlacement.blockPlacementModeDisplayName)
                 .send();
 
         }
@@ -74,23 +75,23 @@ public class FightActionBlockerController implements Listener {
 
             this.announcer.create()
                 .player(uniqueId)
-                .notice(this.config.messages.blockPlacingBlockedDuringCombat)
-                .placeholder("{Y}", String.valueOf(this.config.settings.blockPlacementYCoordinate))
-                .placeholder("{MODE}", this.config.settings.blockPlacementModeDisplayName)
+                .notice(this.config.messagesSettings.blockPlacingBlockedDuringCombat)
+                .placeholder("{Y}", String.valueOf(this.config.blockPlacement.blockPlacementYCoordinate))
+                .placeholder("{MODE}", this.config.blockPlacement.blockPlacementModeDisplayName)
                 .send();
 
         }
     }
 
     private boolean isPlacementBlocked(int level) {
-        return this.config.settings.blockPlacementMode == PluginConfig.Settings.BlockPlacingMode.ABOVE
-            ? level > this.config.settings.blockPlacementYCoordinate
-            : level < this.config.settings.blockPlacementYCoordinate;
+        return this.config.blockPlacement.blockPlacementMode == BlockPlacementSettings.BlockPlacingMode.ABOVE
+            ? level > this.config.blockPlacement.blockPlacementYCoordinate
+            : level < this.config.blockPlacement.blockPlacementYCoordinate;
     }
 
     @EventHandler
     void onToggleGlide(EntityToggleGlideEvent event) {
-        if (!this.config.settings.disableElytraUsage) {
+        if (!this.config.combat.disableElytraUsage) {
             return;
         }
 
@@ -110,7 +111,7 @@ public class FightActionBlockerController implements Listener {
 
     @EventHandler
     void onFly(PlayerToggleFlightEvent event) {
-        if (!this.config.settings.disableFlying) {
+        if (!this.config.combat.disableFlying) {
             return;
         }
 
@@ -130,7 +131,7 @@ public class FightActionBlockerController implements Listener {
 
     @EventHandler
     void onUnTag(FightUntagEvent event) {
-        if (!this.config.settings.disableFlying) {
+        if (!this.config.combat.disableFlying) {
             return;
         }
 
@@ -148,7 +149,7 @@ public class FightActionBlockerController implements Listener {
 
     @EventHandler
     void onDamage(EntityDamageEvent event) {
-        if (!this.config.settings.disableElytraOnDamage) {
+        if (!this.config.combat.disableElytraOnDamage) {
             return;
         }
 
@@ -164,7 +165,7 @@ public class FightActionBlockerController implements Listener {
 
     @EventHandler
     void onOpenInventory(InventoryOpenEvent event) {
-        if (!this.config.settings.disableInventoryAccess) {
+        if (!this.config.combat.disableInventoryAccess) {
             return;
         }
 
@@ -179,7 +180,7 @@ public class FightActionBlockerController implements Listener {
 
         this.announcer.create()
             .player(uniqueId)
-            .notice(this.config.messages.inventoryBlockedDuringCombat)
+            .notice(this.config.messagesSettings.inventoryBlockedDuringCombat)
             .send();
 
     }
@@ -195,10 +196,10 @@ public class FightActionBlockerController implements Listener {
 
         String command = event.getMessage().split(" ")[0].substring(1).toLowerCase();
 
-        boolean isMatchCommand = this.config.settings.restrictedCommands.stream()
+        boolean isMatchCommand = this.config.commands.restrictedCommands.stream()
             .anyMatch(command::startsWith);
 
-        WhitelistBlacklistMode mode = this.config.settings.commandRestrictionMode;
+        WhitelistBlacklistMode mode = this.config.commands.commandRestrictionMode;
 
         boolean shouldCancel = mode.shouldBlock(isMatchCommand);
 
@@ -206,7 +207,7 @@ public class FightActionBlockerController implements Listener {
             event.setCancelled(true);
             this.announcer.create()
                 .player(playerUniqueId)
-                .notice(this.config.messages.commandDisabledDuringCombat)
+                .notice(this.config.messagesSettings.commandDisabledDuringCombat)
                 .send();
 
         }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightMessageController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightMessageController.java
@@ -39,7 +39,7 @@ public class FightMessageController implements Listener {
 
         this.announcer.create()
             .player(player.getUniqueId())
-            .notice(this.config.messages.playerTagged)
+            .notice(this.config.messagesSettings.playerTagged)
             .send();
     }
 
@@ -53,7 +53,7 @@ public class FightMessageController implements Listener {
 
         this.announcer.create()
             .player(player.getUniqueId())
-            .notice(this.config.messages.playerUntagged)
+            .notice(this.config.messagesSettings.playerUntagged)
             .send();
 
     }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightTagController.java
@@ -35,7 +35,7 @@ public class FightTagController implements Listener {
             return;
         }
 
-        List<EntityType> disabledProjectileEntities = this.config.settings.ignoredProjectileTypes;
+        List<EntityType> disabledProjectileEntities = this.config.combat.ignoredProjectileTypes;
 
         if (event.getDamager() instanceof Projectile projectile && disabledProjectileEntities.contains(projectile.getType())) {
             return;
@@ -63,7 +63,7 @@ public class FightTagController implements Listener {
             return;
         }
 
-        if (this.config.settings.disableFlying) {
+        if (this.config.combat.disableFlying) {
             if (attackedPlayerByPerson.isFlying()) {
                 attackedPlayerByPerson.setFlying(false);
                 attackedPlayerByPerson.setAllowFlight(false);
@@ -81,7 +81,7 @@ public class FightTagController implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     void onEntityDamage(EntityDamageEvent event) {
-        if (!this.config.settings.enableDamageCauseLogging) {
+        if (!this.config.combat.enableDamageCauseLogging) {
             return;
         }
 
@@ -101,8 +101,8 @@ public class FightTagController implements Listener {
 
         UUID uuid = player.getUniqueId();
 
-        List<EntityDamageEvent.DamageCause> damageCauses = this.config.settings.loggedDamageCauses;
-        WhitelistBlacklistMode mode = this.config.settings.damageCauseRestrictionMode;
+        List<EntityDamageEvent.DamageCause> damageCauses = this.config.combat.loggedDamageCauses;
+        WhitelistBlacklistMode mode = this.config.combat.damageCauseRestrictionMode;
 
         EntityDamageEvent.DamageCause cause = event.getCause();
 
@@ -135,11 +135,11 @@ public class FightTagController implements Listener {
     }
 
     private boolean cannotBeTagged(Player player) {
-        if (player.getGameMode().equals(GameMode.CREATIVE) && this.config.settings.excludeCreativePlayersFromCombat) {
+        if (player.getGameMode().equals(GameMode.CREATIVE) && this.config.admin.excludeCreativePlayersFromCombat) {
             return true;
         }
 
-        if (player.isOp() && this.config.settings.excludeAdminsFromCombat) {
+        if (player.isOp() && this.config.admin.excludeAdminsFromCombat) {
             return true;
         }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightUnTagController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightUnTagController.java
@@ -34,7 +34,7 @@ public class FightUnTagController implements Listener {
 
         this.fightManager.untag(player.getUniqueId(), cause);
 
-        if (killer != null && this.config.settings.releaseAttackerOnVictimDeath) {
+        if (killer != null && this.config.combat.releaseAttackerOnVictimDeath) {
             this.fightManager.untag(killer.getUniqueId(), CauseOfUnTag.ATTACKER_RELEASE);
         }
     }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
@@ -66,7 +66,7 @@ public class KnockbackRegionController implements Listener {
 
             this.announcer.create()
                 .player(player.getUniqueId())
-                .notice(config -> config.messages.cantEnterOnRegion)
+                .notice(config -> config.messagesSettings.cantEnterOnRegion)
                 .send();
         }
     }
@@ -84,7 +84,7 @@ public class KnockbackRegionController implements Listener {
             event.setCancelled(true);
             this.announcer.create()
                 .player(player.getUniqueId())
-                .notice(config -> config.messages.cantEnterOnRegion)
+                .notice(config -> config.messagesSettings.cantEnterOnRegion)
                 .send();
         }
     }
@@ -107,7 +107,7 @@ public class KnockbackRegionController implements Listener {
 
         this.announcer.create()
             .player(player.getUniqueId())
-            .notice(config -> config.messages.cantEnterOnRegion)
+            .notice(config -> config.messagesSettings.cantEnterOnRegion)
             .send();
     }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/logout/LogoutController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/logout/LogoutController.java
@@ -36,7 +36,7 @@ public class LogoutController implements Listener {
         player.setHealth(0.0);
 
         this.announcer.create()
-            .notice(this.config.messages.playerLoggedOutDuringCombat)
+            .notice(this.config.messagesSettings.playerLoggedOutDuringCombat)
             .placeholder("{PLAYER}", player.getName())
             .all()
             .send();

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/pearl/FightPearlSettings.java
@@ -24,12 +24,12 @@ public class FightPearlSettings extends OkaeriConfig {
 
     @Comment("# Message sent when player tries to throw ender pearl, but are disabled")
     public Notice pearlThrowBlockedDuringCombat = BukkitNotice.builder()
-        .chat("&cThrowing ender pearls is prohibited during combat!")
+        .chat("<red>Throwing ender pearls is prohibited during combat!")
         .build();
 
     @Comment("# Message sent when player tries to throw ender pearl, but has delay")
     public Notice pearlThrowBlockedDelayDuringCombat = BukkitNotice.builder()
-        .chat("&cYou must wait {TIME} before next throw!")
+        .chat("<red>You must wait {TIME} before next throw!")
         .build();
 
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/tagout/FightTagOutCommand.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/tagout/FightTagOutCommand.java
@@ -37,7 +37,7 @@ public class FightTagOutCommand {
         this.fightTagOutService.tagOut(targetUniqueId, time);
 
         this.announcer.create()
-            .notice(this.config.messages.admin.adminTagOutSelf)
+            .notice(this.config.messagesSettings.admin.adminTagOutSelf)
             .placeholder("{TIME}", DurationUtil.format(time))
             .viewer(sender)
             .send();
@@ -51,14 +51,14 @@ public class FightTagOutCommand {
         this.fightTagOutService.tagOut(targetUniqueId, time);
 
         this.announcer.create()
-            .notice(this.config.messages.admin.adminTagOut)
+            .notice(this.config.messagesSettings.admin.adminTagOut)
             .placeholder("{PLAYER}", target.getName())
             .placeholder("{TIME}", DurationUtil.format(time))
             .viewer(sender)
             .send();
 
         this.announcer.create()
-            .notice(this.config.messages.admin.playerTagOut)
+            .notice(this.config.messagesSettings.admin.playerTagOut)
             .placeholder("{TIME}", DurationUtil.format(time))
             .player(target.getUniqueId())
             .send();
@@ -74,14 +74,14 @@ public class FightTagOutCommand {
 
         if (!targetUniqueId.equals(sender.getUniqueId())) {
             this.announcer.create()
-                .notice(this.config.messages.admin.adminTagOutOff)
+                .notice(this.config.messagesSettings.admin.adminTagOutOff)
                 .placeholder("{PLAYER}", target.getName())
                 .viewer(sender)
                 .send();
         }
 
         this.announcer.create()
-            .notice(this.config.messages.admin.playerTagOutOff)
+            .notice(this.config.messagesSettings.admin.playerTagOutOff)
             .player(targetUniqueId)
             .send();
     }
@@ -93,7 +93,7 @@ public class FightTagOutCommand {
         this.fightTagOutService.unTagOut(senderUniqueId);
 
         this.announcer.create()
-            .notice(this.config.messages.admin.playerTagOutOff)
+            .notice(this.config.messagesSettings.admin.playerTagOutOff)
             .viewer(sender)
             .send();
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/handler/InvalidUsageHandlerImpl.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/handler/InvalidUsageHandlerImpl.java
@@ -30,7 +30,7 @@ public class InvalidUsageHandlerImpl implements InvalidUsageHandler<CommandSende
         for (String usage : schematic.all()) {
             this.announcer.create()
                 .viewer(invocation.sender())
-                .notice(this.config.messages.invalidCommandUsage)
+                .notice(this.config.messagesSettings.invalidCommandUsage)
                 .placeholder("{USAGE}", usage)
                 .send();
         }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/handler/MissingPermissionHandlerImpl.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/handler/MissingPermissionHandlerImpl.java
@@ -29,7 +29,7 @@ public class MissingPermissionHandlerImpl implements MissingPermissionsHandler<C
 
         this.announcer.create()
             .viewer(invocation.sender())
-            .notice(this.config.messages.noPermission)
+            .notice(this.config.messagesSettings.noPermission)
             .placeholder("{PERMISSION}", joinedText)
             .send();
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/region/WorldGuardRegionProvider.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/region/WorldGuardRegionProvider.java
@@ -67,7 +67,7 @@ public class WorldGuardRegionProvider implements RegionProvider {
             return true;
         }
 
-        if (this.pluginConfig.settings.preventPvpInRegions) {
+        if (this.pluginConfig.regions.preventPvpInRegions) {
             StateFlag.State flag = region.getFlag(Flags.PVP);
 
             if (flag != null) {


### PR DESCRIPTION
```yaml
#  
#  _____ _     EternalCombat      _ _____                 _           _    
# |  ___| |  o()xxx[{:::::::::>  | /  __ \               | |         | |   
# | |__ | |_ ___ _ __ _ __   __ _| | /  \/ ___  _ __ ___ | |__   __ _| |_  
# |  __|| __/ _ \ '__| '_ \ / _` | | |    / _ \| '_ ` _ \| '_ \ / _` | __| 
# | |___| ||  __/ |  | | | | (_| | | \__/\ (_) | | | | | | |_) | (_| | |_  
# \____/ \__\___|_|  |_| |_|\__,_|_|\____/\___/|_| |_| |_|_.__/ \__,_|\__| 
#  
#  
# Settings for the plugin.
# Modify these to customize the plugin's behavior.
settings:
  # Notify players about new plugin updates when they join the server.
  # Set to 'true' to enable update notifications, or 'false' to disable them.
  notifyAboutUpdates: true
  # The duration (in seconds) that a player remains in combat after being attacked.
  # After this time expires, the player will no longer be considered in combat.
  combatTimerDuration: 20s
  # List of worlds where combat logging is disabled.
  # Players in these worlds will not be tagged or affected by combat rules.
  ignoredWorlds:
  - your_world
#  
# Settings related to Ender Pearls.
# Configure cooldowns, restrictions, and other behaviors for Ender Pearls during combat.
pearl:
  # Is pearl damage to be enabled?
  # This will work globally
  pearlThrowDamageEnabled: true
  # Set true, If you want to lock pearls during the combat
  pearlThrowBlocked: false
  # Block throwing pearls with delay?
  # If you set this to for example 3s, player will have to wait 3 seconds before throwing another pearl
  # Set to 0 to disable
  pearlThrowDelay: 3s
  # Message sent when player tries to throw ender pearl, but are disabled
  pearlThrowBlockedDuringCombat: '&cThrowing ender pearls is prohibited during combat!'
  # Message sent when player tries to throw ender pearl, but has delay
  pearlThrowBlockedDelayDuringCombat: '&cYou must wait {TIME} before next throw!'
#  
# Custom effects applied during combat.
# Configure effects like blindness, slowness, or other debuffs that are applied to players in combat.
effect:
  # Do you want to add effects to players in combat?
  customEffectsEnabled: false
  # If the option above is set to true, you can add effects to players in combat below
  # You can find a list of all potion effects here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html
  # Correct format: 'EFFECT_TYPE:AMPLIFIER' Amplifier strength starts from 0, so level 1 gives effect strength 2
  # Example: SPEED:1, DAMAGE_RESISTANCE:0
  customEffects:
    DAMAGE_RESISTANCE: 0
    SPEED: 1
#  
# Customize how items are dropped when a player dies during combat.
# Configure whether items drop, how they drop, and any additional rules for item drops.
drop:
  # UNCHANGED - The default way of item drop defined by the engine
  # PERCENT - Drops a fixed percentage of items
  # PLAYERS_HEALTH - Drops inverted percentage of the player's health (i.e. if the player has, for example, 80% HP, he will drop 20% of items. Only works when the player escapes from combat by quiting game)
  dropType: UNCHANGED
  # What percentage of items should drop from the player? (Only if Drop Type is set to PERCENT)
  dropItemPercent: 100
  # This option is responsible for the lowest percentage of the player that can drop (i.e. if the player leaves the game while he has 100% of his HP, the percentage of items that is set in this option will drop, if you set this option to 0, then nothing will drop from such a player)
  playersHealthPercentClamp: 20
  # Does the drop modification affect the experience drop?
  affectExperience: false
#  
# Settings related to knockback during combat.
# Configure knockback settings and behaviors for players in combat.
knockback:
  # Adjust the knockback multiplier for restricted regions.
  # Higher values increase the knockback distance. Avoid using negative values.
  # A value of 1.0 typically knocks players 2-4 blocks away.
  multiplier: 1.0
  # Time after which the player will be force knocked back outside the safe zone
  forceDelay: 1s
#  
# Border Settings
# Configure the border that appears during combat.
border:
  # Border view distance in blocks
  distance: 6.5
  #  
  # Border block animation settings
  # Configure the block animation that appears during combat.
  block:
    # Enable block animation?
    enabled: true
    # Block type used for rendering the border
    # Custom: RAINBOW_GLASS, RAINBOW_WOOL, RAINBOW_TERRACOTTA, RAINBOW_CONCRETE
    # Vanilla: https://javadocs.packetevents.com/com/github/retrooper/packetevents/protocol/world/states/type/StateTypes.html
    type: RAINBOW_GLASS
    # Delay between each async animation update
    # Lower values will decrease performance but will make the animation smoother
    # Higher values will increase performance
    updateDelay: 250ms
    # Delay between each chunk cache update
    # Lower values will decrease performance
    # Higher values will increase performance but may cause overlapping existing blocks (this does not modify the world)
    chunkCacheDelay: 300ms
  #  
  # Border particle animation settings
  # Configure the particle animation that appears during combat.
  particle:
    # Enable particle animation?
    enabled: true
    # Particle type - https://javadocs.packetevents.com/com/github/retrooper/packetevents/protocol/particle/type/ParticleTypes.html
    type: DUST
    # Particle color (used only for DUST or ENTITY_EFFECT particle type)
    # You can set hex color e.g. "#ca4c45" or use "RAINBOW" to generate rainbow gradient based on x and z coordinates.
    color: RAINBOW
    count: 5
    scale: 1.0
    maxSpeed: 0.0
    offsetX: 0.2
    offsetY: 0.2
    offsetZ: 0.2
#  
# Settings related to block placement during combat.
# Configure restrictions and behaviors for block placement while players are in combat.
blockPlacement:
  # Prevent players from placing blocks during combat.
  # Set to 'true' to block block placement while in combat.
  disableBlockPlacing: true
  # Restrict block placement above or below a specific Y coordinate.
  # Available modes: ABOVE (blocks cannot be placed above the Y coordinate), BELOW (blocks cannot be placed below the Y coordinate).
  blockPlacementMode: ABOVE
  # Custom name for the block placement mode used in messages.
  # This name will be displayed in notifications related to block placement restrictions.
  blockPlacementModeDisplayName: above
  # Define the Y coordinate for block placement restrictions.
  # This value is relative to the selected block placement mode (ABOVE or BELOW).
  blockPlacementYCoordinate: 40
  # Restrict the placement of specific blocks during combat.
  # Add blocks to this list to prevent their placement. Leave the list empty to block all blocks.
  # Note: This feature requires 'disableBlockPlacing' to be enabled.
  restrictedBlockTypes: []
#  
# Settings related to commands during combat.
# Configure command restrictions and behaviors for players in combat.
commands:
  # Set the mode for command restrictions during combat.
  # Available modes: WHITELIST (only listed commands are allowed), BLACKLIST (listed commands are blocked).
  commandRestrictionMode: BLACKLIST
  # List of commands affected by the command restriction mode.
  # In BLACKLIST mode, these commands are blocked. In WHITELIST mode, only these commands are allowed.
  restrictedCommands:
  - gamemode
  - spawn
  - tp
  - tpa
  - tpaccept
#  
# Settings related to the plugin's admin commands and features.
# Configure admin-specific settings and behaviors for the plugin.
admin:
  # Exclude server administrators from combat tagging and being tagged.
  # Set to 'true' to prevent admins from being tagged or tagging others.
  # Set to 'false' to allow admins to participate in combat.
  excludeAdminsFromCombat: false
  # Exclude players in creative mode from combat tagging and being tagged.
  # Set to 'true' to prevent creative mode players from being tagged or tagging others.
  # Set to 'false' to allow creative mode players to participate in combat.
  excludeCreativePlayersFromCombat: false
#  
# Settings related to regions.
# Configure region-specific settings and behaviors for combat.
regions:
  # List of regions where combat is restricted.
  # Players in these regions will not be able to engage in combat.
  blockedRegions:
  - your_region
  # Prevent players from entering regions where PVP is disabled by WorldGuard.
  # Set to 'true' to enforce this restriction, or 'false' to allow PVP in all regions.
  preventPvpInRegions: true
  # Define the radius of restricted regions if WorldGuard is not used.
  # This setting is based on the default spawn region.
  restrictedRegionRadius: 10
#  
# Settings related to combat and player tagging.
# Configure combat rules, and behaviors for player tagging.
combat:
  # Automatically release the attacker from combat when the victim dies.
  # Set to 'true' to enable this feature, or 'false' to keep the attacker in combat.
  releaseAttackerOnVictimDeath: true
  # Disable the use of elytra during combat.
  # Set to 'true' to prevent players from using elytra while in combat.
  disableElytraUsage: true
  # Disable the use of elytra when a player takes damage.
  # Set to 'true' to disable elytra usage upon taking damage, even when the player is mid-air.
  disableElytraOnDamage: true
  # Prevent players from flying during combat.
  # Flying players will fall to the ground if this is enabled.
  disableFlying: true
  # Prevent players from opening their inventory during combat.
  # Set to 'true' to block inventory access while in combat.
  disableInventoryAccess: false
  # Enable or disable combat logging for damage caused by non-player entities.
  # Set to 'true' to log damage from non-player sources, or 'false' to disable this feature.
  enableDamageCauseLogging: false
  # Set the mode for logging damage causes.
  # Available modes: WHITELIST (only listed causes are logged), BLACKLIST (all causes except listed ones are logged).
  damageCauseRestrictionMode: WHITELIST
  # List of damage causes to be logged based on the selected mode.
  # In WHITELIST mode, only these causes are logged. In BLACKLIST mode, all causes except these are logged.
  # For a full list of damage causes, visit: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html
  loggedDamageCauses:
  - LAVA
  - CONTACT
  - FIRE
  - FIRE_TICK
  # List of projectile types that do not trigger combat tagging.
  # Players hit by these projectiles will not be tagged as in combat.
  # For a full list of entity types, visit: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
  ignoredProjectileTypes:
  - ENDER_PEARL
  - EGG
#  
# Customize the messages displayed by the plugin.
# Modify these to change the text and formatting of notifications and alerts.
messagesSettings:
  # Customize messages related to admin commands and notifications.
  # These messages are displayed to server administrators.
  admin:
    # Message displayed when the console attempts to use a player-only command.
    # This message informs the console that the command is not available for non-players.
    onlyForPlayers: <gradient:red:dark_red>❌ This command is player-only!</gradient>
    # Message displayed to an admin when they tag a player.
    # The {PLAYER} placeholder is replaced with the tagged player's name.
    adminTagPlayer: <gradient:#00b3ff:#0066ff>⚔ <gray>Tagged player:</gray> <white>{PLAYER}</white></gradient>
    # Message displayed when an admin tags multiple players.
    # The {FIRST_PLAYER} and {SECOND_PLAYER} placeholders are replaced with the players' names.
    adminTagMultiplePlayers: <gradient:#00b3ff:#0066ff>⚔ <gray>Tagged:</gray> <white>{FIRST_PLAYER}</white>
      <gray>and</gray> <white>{SECOND_PLAYER}</white></gradient>
    # Message displayed to an admin when they remove a player from combat.
    # The {PLAYER} placeholder is replaced with the player's name.
    adminUntagPlayer: <gradient:#00ff88:#00b300>✌ <gray>Removed</gray> <white>{PLAYER}</white>
      <gray>from combat</gray></gradient>
    # Message displayed when an admin attempts to untag a player who is not in combat.
    # This message informs the admin that the player is not currently in combat.
    adminPlayerNotInCombat: <gradient:red:dark_red>❌ <white>{PLAYER}</white> is not
      in combat!</gradient>
    # Message displayed when a player is in combat.
    # The {PLAYER} placeholder is replaced with the player's name.
    playerInCombat: <gradient:#ff6666:#ff0000>⚔ <white>{PLAYER}</white> <gray>is in
      combat!</gray></gradient>
    # Message displayed when a player is not in combat.
    # The {PLAYER} placeholder is replaced with the player's name.
    playerNotInCombat: <gradient:#00ff00:#00b300>✌ <white>{PLAYER}</white> <gray>is
      safe</gray></gradient>
    # Message displayed when an admin attempts to tag themselves.
    # This message informs the admin that they cannot tag themselves.
    adminCannotTagSelf: <gradient:red:dark_red>❌ Cannot tag yourself!</gradient>
    # Message displayed when an admin disables combat tagging for themselves.
    # The {TIME} placeholder is replaced with the remaining fight time.
    adminTagOutSelf: <gradient:#00b3ff:#0066ff>🛡 <gray>Self-protection active for</gray>
      <white>{TIME}</white></gradient>
    # Message displayed when an admin disables combat tagging for another player.
    # The {PLAYER} placeholder is replaced with the player's name.
    # The {TIME} placeholder is replaced with the remaining fight time.
    adminTagOut: <gradient:#00b3ff:#0066ff>🛡 <gray>Protected</gray> <white>{PLAYER}</white>
      <gray>for</gray> <white>{TIME}</white></gradient>
    # Message displayed to a player when their combat tagging is disabled.
    # The {TIME} placeholder is replaced with the remaining fight time.
    playerTagOut: <gradient:#00ff88:#00b300>🛡 <gray>Protection active for</gray>
      <white>{TIME}</white></gradient>
    # Message displayed when an admin reenables combat tagging for a player.
    # The {PLAYER} placeholder is replaced with the player's name.
    adminTagOutOff: <gradient:#00ff88:#00b300>✌ <gray>Re-enabled tagging for</gray>
      <white>{PLAYER}</white></gradient>
    # Message displayed to a player when their combat tagging is reenabled.
    # This message informs the player that they can now be tagged again.
    playerTagOutOff: ''
    # Message displayed when an admin attempts to tag a player who has tag-out enabled.
    # This message informs the admin that the player cannot be tagged at this time.
    adminTagOutCanceled: <gradient:red:dark_red>❌ Player has tag-out protection!</gradient>
  #  
  # Configure the combat log notification displayed to players.
  # You can use the {TIME} variable to display the remaining combat time.
  #  
  # BossBar progress: Set to -1.0 to show the remaining combat time as a progress bar.
  # BossBar colors: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Color.html
  # BossBar overlays: https://javadoc.io/static/net.kyori/adventure-api/4.14.0/net/kyori/adventure/bossbar/BossBar.Overlay.html
  combatNotification:
    actionbar: '<bold>Combat ends in: <red>{TIME}</red></bold>'
    sound: ENTITY_EXPERIENCE_ORB_PICKUP PLAYERS 1.0 2.0
  # Message displayed when a player lacks permission to execute a command.
  # The {PERMISSION} placeholder is replaced with the required permission.
  noPermission: <gradient:red:dark_red>You don't have permission <dark_gray>(<gray>{PERMISSION}</gray>)</dark_gray>
    to perform this command!</gradient>
  # Message displayed when a specified player is not found.
  # This message is shown when a command targets a player who is not online or does not exist.
  playerNotFound: <gradient:#ff0000:#ff6b6b>The specified player could not be found!</gradient>
  # Message displayed when a player enters combat.
  # This message warns the player not to leave the server while in combat.
  playerTagged: <gradient:red:yellow>⚠ <white>You are in combat!</white> <u>Do not
    leave the server!</gradient>
  # Message displayed when a player leaves combat.
  # This message informs the player that they can safely leave the server.
  playerUntagged: <gradient:#00ff00:#00b300>✌ <white>Combat ended!</white> You can
    now safely leave!</u></gradient>
  # Broadcast message displayed when a player logs out during combat.
  # The {PLAYER} placeholder is replaced with the player's name.
  playerLoggedOutDuringCombat: <gradient:red:dark_red>⚠ <white>{PLAYER}</white> logged
    off during combat!</gradient>
  # Message displayed when a player attempts to use a disabled command during combat.
  # This message informs the player that the command is prohibited while in combat.
  commandDisabledDuringCombat: <gradient:red:yellow>⚠ <white>Command blocked!</white>
    Cannot use this during combat!</gradient>
  # Message displayed when a player uses a command with incorrect arguments.
  # The {USAGE} placeholder is replaced with the correct command syntax.
  invalidCommandUsage: '<gray>Usage: <gradient:gold:yellow>{USAGE}</gradient>'
  # Message displayed when a player attempts to open their inventory during combat.
  # This message informs the player that inventory access is blocked while in combat.
  inventoryBlockedDuringCombat: <gradient:red:dark_red>⚠ <white>Inventory access</white>
    is restricted during combat!</gradient>
  # Message displayed when a player attempts to place a block during combat.
  # The {MODE} placeholder is replaced with the block placement mode (ABOVE/BELOW).
  # The {Y} placeholder is replaced with the Y coordinate set in the config.
  blockPlacingBlockedDuringCombat: <gradient:red:yellow>⚠ Block placement <white>{MODE}
    Y:{Y}</white> is restricted!</gradient>
  # Message displayed when a player attempts to enter a restricted region during combat.
  # This message informs the player that they cannot enter the region while in combat.
  cantEnterOnRegion: <gradient:red:dark_red>⚠ Restricted area!</gradient> <white>Cannot
    enter during combat!</white>
```