### PR TITLE
GH-224 Add option to not kill the player on logout - message will be sent regardless

### DIFF
--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/config/implementation/PluginConfig.java
@@ -119,6 +119,11 @@ public class PluginConfig extends OkaeriConfig {
         public Duration combatTimerDuration = Duration.ofSeconds(20);
 
         @Comment({
+            "# Should plugin kill players on combat log?",
+        })
+        public boolean shouldPlayerBeKilledOnCombatLog = true;
+
+        @Comment({
             "# List of worlds where combat logging is disabled.",
             "# Players in these worlds will not be tagged or affected by combat rules."
         })

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/logout/LogoutController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/logout/LogoutController.java
@@ -32,8 +32,10 @@ public class LogoutController implements Listener {
             return;
         }
 
-        this.logoutService.punishForLogout(player);
-        player.setHealth(0.0);
+        if (this.config.settings.shouldPlayerBeKilledOnCombatLog) {
+            this.logoutService.punishForLogout(player);
+            player.setHealth(0.0);
+        }
 
         this.noticeService.create()
             .notice(this.config.messagesSettings.playerLoggedOutDuringCombat)


### PR DESCRIPTION
Users can turn off setting health to 0.0 on log out - so the player is not killed during logout  but message is still sent