### PR TITLE
Add better way to check restricted command - previous idea only checked root commands

### DIFF
--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightActionBlockerController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/controller/FightActionBlockerController.java
@@ -6,6 +6,7 @@ import com.eternalcode.combat.config.implementation.BlockPlacementSettings;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.combat.fight.event.FightUntagEvent;
 import com.eternalcode.combat.notification.NoticeService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -194,14 +195,21 @@ public class FightActionBlockerController implements Listener {
             return;
         }
 
-        String command = event.getMessage().split(" ")[0].substring(1).toLowerCase();
+        String message = event.getMessage();
 
-        boolean isMatchCommand = this.config.commands.restrictedCommands.stream()
-            .anyMatch(command::startsWith);
+        String fullCommand = message.substring(1);
+
+        AtomicBoolean isAnyMatch = new AtomicBoolean(false);
+
+        this.config.commands.restrictedCommands.forEach(restrictedCommand -> {
+            if (fullCommand.startsWith(restrictedCommand)) {
+                isAnyMatch.set(true);
+            }
+        });
 
         WhitelistBlacklistMode mode = this.config.commands.commandRestrictionMode;
 
-        boolean shouldCancel = mode.shouldBlock(isMatchCommand);
+        boolean shouldCancel = mode.shouldBlock(isAnyMatch.get());
 
         if (shouldCancel) {
             event.setCancelled(true);


### PR DESCRIPTION
Now algorithm checks for matching first words.

meaning:
restrictedCommands:
 - gamemode
 - tpa CitralFlo
 
should block all gamemode commands, and all tpa requests to CitralFlo (not anyone else)
 