### PR TITLE
Updated packetEvents to latest

### DIFF
--- a/eternalcombat-plugin/build.gradle.kts
+++ b/eternalcombat-plugin/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     // Multification
     implementation("com.eternalcode:multification-bukkit:${Versions.MULTIFICATION}")
     implementation("com.eternalcode:multification-okaeri:${Versions.MULTIFICATION}")
-    implementation("com.github.retrooper:packetevents-spigot:${Versions.PACKETS_EVENTS}")
+    implementation("com.github.retrooper:packetevents-spigot:2.8.0")
     implementation("io.papermc:paperlib:${Versions.PAPERLIB}")
 }
 


### PR DESCRIPTION
The latest version of PacketEvents supports 1.21.5, add I did was change this and it worked flawlessly on 1.21.5