### PR TITLE
GH-305 Update GitHub Actions workflow to set build label for each branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,9 +31,8 @@ jobs:
             const isPR = context.eventName === 'pull_request';
             const branch = (isPR ? context.payload.pull_request.head.ref : context.ref_name).replace(/\//g, '-');
             const sha = (isPR ? context.payload.pull_request.head.sha : context.sha).substring(0, 7);
-            const isMaster = context.ref === 'refs/heads/master';
             
-            const artifactName = `EternalCombat ${branch}${isMaster ? '' : ' - Snapshot'}+${sha}`;
+            const artifactName = `EternalCombat ${branch}+${sha}`;
             core.exportVariable('FULL_ARTIFACT_NAME', artifactName);
 
       - name: Build with Gradle


### PR DESCRIPTION
Example artifact names:
For master branch:
`EternalCombat master 15`

For feature/combat-rework branch:
`EternalCombat feature/combat-rework - Snapshot 16`

Where 15 and 16 means runner runs - making versions more **distinct** - GitHub does not collect and store number of runs on specific branch or pull request 