### PR TITLE
fix: prevent delayed knockback teleport from overriding /back after death. Reported on Discord.

### DIFF
--- a/eternalcombat-api/src/main/java/com/eternalcode/combat/region/Region.java
+++ b/eternalcombat-api/src/main/java/com/eternalcode/combat/region/Region.java
@@ -1,6 +1,7 @@
 package com.eternalcode.combat.region;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 
 public interface Region {
 
@@ -11,6 +12,18 @@ public interface Region {
     Location getMax();
 
     default boolean contains(Location location) {
+        if (location == null) {
+            return false;
+        }
+
+        Location min = this.getMin();
+        World regionWorld = min.getWorld();
+        World locationWorld = location.getWorld();
+
+        if (regionWorld == null || locationWorld == null || !regionWorld.equals(locationWorld)) {
+            return false;
+        }
+
         return this.contains(location.getX(), location.getY(), location.getZ());
     }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -139,7 +139,7 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
 
         this.regionProvider = bridgeService.getRegionProvider();
         BorderService borderService = new BorderServiceImpl(scheduler, server, regionProvider, eventManager, () -> pluginConfig.border);
-        KnockbackService knockbackService = new KnockbackService(pluginConfig, scheduler, regionProvider);
+        KnockbackService knockbackService = new KnockbackService(pluginConfig, this.fightManager, scheduler, regionProvider);
 
         this.liteCommands = LiteBukkitFactory.builder(FALLBACK_PREFIX, this, server)
             .message(LiteBukkitMessages.PLAYER_NOT_FOUND, pluginConfig.messagesSettings.playerNotFound)

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -139,7 +139,7 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
 
         this.regionProvider = bridgeService.getRegionProvider();
         BorderService borderService = new BorderServiceImpl(scheduler, server, regionProvider, eventManager, () -> pluginConfig.border);
-        KnockbackService knockbackService = new KnockbackService(pluginConfig, this.fightManager, scheduler, regionProvider);
+        KnockbackService knockbackService = new KnockbackService(pluginConfig, this.fightManager, scheduler, regionProvider, server);
 
         this.liteCommands = LiteBukkitFactory.builder(FALLBACK_PREFIX, this, server)
             .message(LiteBukkitMessages.PLAYER_NOT_FOUND, pluginConfig.messagesSettings.playerNotFound)

--- a/eternalcombat-plugin/test/com/eternalcode/combat/region/RegionContainsWorldCheckTest.java
+++ b/eternalcombat-plugin/test/com/eternalcode/combat/region/RegionContainsWorldCheckTest.java
@@ -1,0 +1,38 @@
+package com.eternalcode.combat.region;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+class RegionContainsWorldCheckTest {
+
+    @Test
+    void shouldNotContainLocationFromDifferentWorld() {
+        World regionWorld = mock(World.class);
+        World otherWorld = mock(World.class);
+
+        Region region = new Region() {
+            @Override
+            public Point getCenter() {
+                return new Point(regionWorld, 5.0, 5.0);
+            }
+
+            @Override
+            public Location getMin() {
+                return new Location(regionWorld, 0.0, 0.0, 0.0);
+            }
+
+            @Override
+            public Location getMax() {
+                return new Location(regionWorld, 10.0, 10.0, 10.0);
+            }
+        };
+
+        Location locationInOtherWorld = new Location(otherWorld, 5.0, 5.0, 5.0);
+
+        assertFalse(region.contains(locationInOtherWorld));
+    }
+}


### PR DESCRIPTION
This PR fixes a race condition in EternalCombat where a delayed knockback/teleport could still run after player death and overwrite the location used by /back (Essentials/HuskHomes). It also fixes region checks to include world validation (World), not only coordinates.