### PR TITLE
Fix import statement for EntityMountEvent

### DIFF
--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
@@ -17,7 +17,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 
 public class KnockbackRegionController implements Listener {
 


### PR DESCRIPTION
---
name: Pull Request
about: Submit a contribution to EternalCombat
title: 'Fix EntityMountEvent import statement'
---

## 📝 Description
Fixed a broken import statement for `EntityMountEvent`, which was causing compilation errors or runtime issues.

## 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔧 Refactoring (no functional changes, just code improvements)
- [ ] 🎨 Style/Cosmetic (formatting, whitespace, visual changes)
- [ ] 📚 Documentation (updates to documentation or README)
- [ ] 🤖 CI/CD/Build (changes to workflows, gradle, etc.)

## 🧪 How Has This Been Tested?
- [x] **Compile Test:** Project builds successfully with the corrected import.
- [x] **Runtime Test:** Verified that mounting/dismounting entities triggers the combat mechanics correctly without throwing "Failed to register events for class com.eternalcode.combat.fight.knockback.KnockbackRegionController because org/spigotmc/event/entity/EntityMountEvent does not exist"

**Test Environment:**
- **Minecraft Version:** 26.1.2
- **Java Version:** 26
- **Platform:** Linux