### PR TITLE
[codex] Fix combat runtime issues

### DIFF
--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -192,8 +192,8 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
             new TridentController(pluginConfig, noticeService, this.fightManager, this.tridentService, server),
             new DeathFlareController(pluginConfig, server, scheduler, this),
             new DeathLightningController(pluginConfig, server),
-            new UpdaterNotificationController(updaterService, pluginConfig, miniMessage),
-            new KnockbackRegionController(noticeService, this.regionProvider, this.fightManager, knockbackService, server),
+            new UpdaterNotificationController(updaterService, pluginConfig, miniMessage, scheduler),
+            new KnockbackRegionController(noticeService, this.regionProvider, this.fightManager, knockbackService, server, this),
             new FightEffectController(pluginConfig.effect, this.fightEffectService, this.fightManager, server),
             new FightTagOutController(this.fightTagOutService),
             new FightMessageController(this.fightManager, noticeService, pluginConfig, server),
@@ -207,8 +207,7 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
             new CommandsBlocker(this.fightManager, noticeService, pluginConfig),
             new ElytraBlocker(this.fightManager, pluginConfig),
             new ElytraEquipBlocker(this.fightManager, noticeService, pluginConfig, server),
-            new FlyingBlocker(this.fightManager, pluginConfig, server),
-            new PlaceBlockBlocker(this.fightManager, noticeService, pluginConfig)
+            new FlyingBlocker(this.fightManager, pluginConfig, server)
         );
 
         eventManager.subscribe(

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/EternalCombatReloadCommand.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/EternalCombatReloadCommand.java
@@ -4,7 +4,6 @@ import com.eternalcode.combat.config.ConfigService;
 import com.eternalcode.combat.notification.NoticeService;
 import com.eternalcode.multification.notice.Notice;
 import com.google.common.base.Stopwatch;
-import dev.rollczi.litecommands.annotations.async.Async;
 import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
@@ -27,7 +26,6 @@ public class EternalCombatReloadCommand {
         this.noticeService = noticeService;
     }
 
-    @Async
     @Execute(name = "reload")
     @Permission("eternalcombat.reload")
     void execute(@Context CommandSender sender) {

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/border/BorderTriggerIndex.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/border/BorderTriggerIndex.java
@@ -3,13 +3,12 @@ package com.eternalcode.combat.border;
 import com.eternalcode.combat.region.Region;
 import com.eternalcode.combat.region.RegionProvider;
 import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
-import com.eternalcode.commons.scheduler.Scheduler;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -22,7 +21,7 @@ class BorderTriggerIndex {
     private final RegionProvider provider;
     private final Supplier<BorderSettings> settings;
 
-    private final Map<String, BorderTriggerIndexBucket> borderIndexes = new HashMap<>();
+    private final Map<String, BorderTriggerIndexBucket> borderIndexes = new ConcurrentHashMap<>();
 
     private BorderTriggerIndex(Server server, MinecraftScheduler scheduler, RegionProvider provider, Supplier<BorderSettings> settings) {
         this.server = server;
@@ -38,28 +37,26 @@ class BorderTriggerIndex {
     }
 
     private void updateWorld(String world, Collection<Region> regions) {
-        this.scheduler.runAsync(() -> {
-            int distanceRounded = settings.get().distanceRounded();
-            List<BorderTrigger> triggers = new ArrayList<>();
-            for (Region region : regions) {
-                Location min = region.getMin();
-                Location max = region.getMax();
+        int distanceRounded = settings.get().distanceRounded();
+        List<BorderTrigger> triggers = new ArrayList<>();
+        for (Region region : regions) {
+            Location min = region.getMin();
+            Location max = region.getMax();
 
-                triggers.add(new BorderTrigger(
-                    min.getBlockX(), min.getBlockY(), min.getBlockZ(),
-                    max.getBlockX() + 1, max.getBlockY() + 1, max.getBlockZ() + 1,
-                    distanceRounded
-                ));
-            }
+            triggers.add(new BorderTrigger(
+                min.getBlockX(), min.getBlockY(), min.getBlockZ(),
+                max.getBlockX() + 1, max.getBlockY() + 1, max.getBlockZ() + 1,
+                distanceRounded
+            ));
+        }
 
-            BorderTriggerIndexBucket index = BorderTriggerIndexBucket.create(triggers);
-            this.borderIndexes.put(world, index);
-        });
+        BorderTriggerIndexBucket index = BorderTriggerIndexBucket.create(triggers);
+        this.borderIndexes.put(world, index);
     }
 
     static BorderTriggerIndex started(Server server, MinecraftScheduler scheduler, RegionProvider provider, Supplier<BorderSettings> settings) {
         BorderTriggerIndex index = new BorderTriggerIndex(server, scheduler, provider, settings);
-        scheduler.timerAsync(() -> index.updateWorlds(), Duration.ZERO, settings.get().indexRefreshDelay());
+        scheduler.timer(() -> index.updateWorlds(), Duration.ZERO, settings.get().indexRefreshDelay());
         return index;
     }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/death/DeathFlareController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/death/DeathFlareController.java
@@ -3,7 +3,7 @@ package com.eternalcode.combat.fight.death;
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.combat.fight.event.CauseOfUnTag;
 import com.eternalcode.combat.fight.event.FightUntagEvent;
-import com.eternalcode.commons.scheduler.Scheduler;
+import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
 import java.time.Duration;
 import java.util.UUID;
 import org.bukkit.Color;
@@ -27,10 +27,10 @@ public class DeathFlareController implements Listener {
 
     private final PluginConfig pluginConfig;
     private final Server server;
-    private final Scheduler scheduler;
+    private final MinecraftScheduler scheduler;
     private final NamespacedKey key;
 
-    public DeathFlareController(PluginConfig pluginConfig, Server server, Scheduler scheduler, Plugin plugin) {
+    public DeathFlareController(PluginConfig pluginConfig, Server server, MinecraftScheduler scheduler, Plugin plugin) {
         this.pluginConfig = pluginConfig;
         this.server = server;
         this.scheduler = scheduler;
@@ -65,7 +65,7 @@ public class DeathFlareController implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (event.getDamager() instanceof Firework firework && firework.getPersistentDataContainer().has(key, PersistentDataType.STRING)) {
             event.setCancelled(true);
@@ -102,7 +102,8 @@ public class DeathFlareController implements Listener {
     }
 
     private void scheduleParticles(Firework flare, World world) {
-        this.scheduler.runLaterAsync(
+        this.scheduler.runLater(
+            flare.getLocation(),
             () -> {
                 if (flare.isDead() || !flare.isValid()) {
                     return;

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
@@ -141,7 +141,7 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
                 .toArray(new ItemStack[0]);
 
             HashMap<Integer, ItemStack> leftover = playerInventory.addItem(itemsToGive);
-            leftover.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
+            leftover.values().forEach(item -> event.getRespawnLocation().getWorld().dropItemNaturally(event.getRespawnLocation(), item));
         }
     }
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
@@ -15,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -85,8 +86,8 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
             return false;
         }
 
-        if (this.dropSettings.headDropOnlyInCombat && inCombat) {
-            return true;
+        if (this.dropSettings.headDropOnlyInCombat && !inCombat) {
+            return false;
         }
 
         if (this.dropSettings.headDropChance <= 0.0) {
@@ -139,7 +140,8 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
             ItemStack[] itemsToGive = this.keepInventoryManager.nextItems(playerUniqueId)
                 .toArray(new ItemStack[0]);
 
-            playerInventory.addItem(itemsToGive);
+            HashMap<Integer, ItemStack> leftover = playerInventory.addItem(itemsToGive);
+            leftover.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
         }
     }
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PercentDropModifier.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PercentDropModifier.java
@@ -27,10 +27,11 @@ public class PercentDropModifier implements DropModifier {
 
     @Override
     public DropResult modifyDrop(Drop drop) {
-        int dropItemPercent = 100 - MathUtil.clamp(this.settings.dropItemPercent, 0, 100);
+        int dropItemPercent = MathUtil.clamp(this.settings.dropItemPercent, 0, 100);
+        int keepItemPercent = 100 - dropItemPercent;
         List<ItemStack> droppedItems = drop.getDroppedItems();
 
-        int itemsToDelete = InventoryUtil.calculateItemsToDelete(dropItemPercent, droppedItems, ItemStack::getAmount);
+        int itemsToDelete = InventoryUtil.calculateItemsToDelete(keepItemPercent, droppedItems, ItemStack::getAmount);
         int droppedExp = MathUtil.getRoundedCountFromPercentage(dropItemPercent, drop.getDroppedExp());
 
         RemoveItemResult result = InventoryUtil.removeRandomItems(droppedItems, itemsToDelete);

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PlayersHealthDropModifier.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PlayersHealthDropModifier.java
@@ -50,10 +50,11 @@ public class PlayersHealthDropModifier implements DropModifier {
         double health = logout.health();
 
         int percentHealth = MathUtil.getRoundedCountPercentage(health, maxHealth);
-        int reversedPercent = MathUtil.clamp(100 - percentHealth, this.settings.playersHealthPercentClamp, 100);
+        int dropPercent = MathUtil.clamp(100 - percentHealth, this.settings.playersHealthPercentClamp, 100);
+        int keepPercent = 100 - dropPercent;
 
-        int itemsToDelete = InventoryUtil.calculateItemsToDelete(reversedPercent, droppedItems, ItemStack::getAmount);
-        int droppedExp = MathUtil.getRoundedCountFromPercentage(reversedPercent, drop.getDroppedExp());
+        int itemsToDelete = InventoryUtil.calculateItemsToDelete(keepPercent, droppedItems, ItemStack::getAmount);
+        int droppedExp = MathUtil.getRoundedCountFromPercentage(dropPercent, drop.getDroppedExp());
 
         RemoveItemResult result = InventoryUtil.removeRandomItems(droppedItems, itemsToDelete);
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PlayersHealthDropModifier.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/impl/PlayersHealthDropModifier.java
@@ -11,6 +11,7 @@ import com.eternalcode.combat.util.InventoryUtil;
 import com.eternalcode.combat.util.MathUtil;
 import com.eternalcode.combat.util.RemoveItemResult;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -46,7 +47,9 @@ public class PlayersHealthDropModifier implements DropModifier {
 
         List<ItemStack> droppedItems = drop.getDroppedItems();
 
-        double maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+        double maxHealth = Optional.ofNullable(player.getAttribute(Attribute.GENERIC_MAX_HEALTH))
+            .map(AttributeInstance::getValue)
+            .orElse(20.0);
         double health = logout.health();
 
         int percentHealth = MathUtil.getRoundedCountPercentage(health, maxHealth);

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
@@ -37,6 +37,7 @@ public class KnockbackRegionController implements Listener {
     private final FightManager fightManager;
     private final KnockbackService knockbackService;
     private final Server server;
+    private Method getMountMethod;
 
     public KnockbackRegionController(NoticeService noticeService, RegionProvider regionProvider, FightManager fightManager, KnockbackService knockbackService, Server server, Plugin plugin) {
         this.noticeService = noticeService;
@@ -152,6 +153,13 @@ public class KnockbackRegionController implements Listener {
             return;
         }
 
+        try {
+            this.getMountMethod = eventClass.get().getMethod("getMount");
+        } catch (NoSuchMethodException exception) {
+            plugin.getLogger().warning("Failed to find getMount method on " + eventClass.get().getName());
+            return;
+        }
+
         EventExecutor executor = this::onEntityMount;
         plugin.getServer().getPluginManager().registerEvent(eventClass.get(), this, EventPriority.HIGHEST, executor, plugin, true);
     }
@@ -197,17 +205,20 @@ public class KnockbackRegionController implements Listener {
     }
 
     private Entity getMount(Event event) {
+        if (this.getMountMethod == null) {
+            return null;
+        }
+
         try {
-            Method getMount = event.getClass().getMethod("getMount");
-            Object mount = getMount.invoke(event);
+            Object mount = this.getMountMethod.invoke(event);
 
             if (mount instanceof Entity entity) {
                 return entity;
             }
 
             return null;
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
-            throw new IllegalStateException("Cannot read mount from " + event.getClass().getName(), exception);
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            return null;
         }
     }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
@@ -5,21 +5,32 @@ import com.eternalcode.combat.fight.event.FightTagEvent;
 import com.eternalcode.combat.notification.NoticeService;
 import com.eternalcode.combat.region.Region;
 import com.eternalcode.combat.region.RegionProvider;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Optional;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
-import org.spigotmc.event.entity.EntityMountEvent;
+import org.bukkit.plugin.EventExecutor;
+import org.bukkit.plugin.Plugin;
 
 public class KnockbackRegionController implements Listener {
+
+    private static final String[] ENTITY_MOUNT_EVENT_CLASSES = {
+        "org.bukkit.event.entity.EntityMountEvent",
+        "org.spigotmc.event.entity.EntityMountEvent"
+    };
 
     private final NoticeService noticeService;
     private final RegionProvider regionProvider;
@@ -27,12 +38,14 @@ public class KnockbackRegionController implements Listener {
     private final KnockbackService knockbackService;
     private final Server server;
 
-    public KnockbackRegionController(NoticeService noticeService, RegionProvider regionProvider, FightManager fightManager, KnockbackService knockbackService, Server server) {
+    public KnockbackRegionController(NoticeService noticeService, RegionProvider regionProvider, FightManager fightManager, KnockbackService knockbackService, Server server, Plugin plugin) {
         this.noticeService = noticeService;
         this.regionProvider = regionProvider;
         this.fightManager = fightManager;
         this.knockbackService = knockbackService;
         this.server = server;
+
+        this.registerEntityMountEvent(plugin);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
@@ -132,9 +145,35 @@ public class KnockbackRegionController implements Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    void onEntityMount(EntityMountEvent event) {
-        if (!(event.getEntity() instanceof Player player)) {
+    private void registerEntityMountEvent(Plugin plugin) {
+        Optional<Class<? extends Event>> eventClass = this.findEntityMountEventClass();
+        if (eventClass.isEmpty()) {
+            plugin.getLogger().fine("EntityMountEvent is not available. Mount region protection will be disabled.");
+            return;
+        }
+
+        EventExecutor executor = this::onEntityMount;
+        plugin.getServer().getPluginManager().registerEvent(eventClass.get(), this, EventPriority.HIGHEST, executor, plugin, true);
+    }
+
+    private Optional<Class<? extends Event>> findEntityMountEventClass() {
+        for (String eventClassName : ENTITY_MOUNT_EVENT_CLASSES) {
+            try {
+                return Optional.of(Class.forName(eventClassName).asSubclass(Event.class));
+            } catch (ClassNotFoundException ignored) {
+                // Try the next API package.
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private void onEntityMount(Listener listener, Event event) {
+        if (!(event instanceof EntityEvent entityEvent)) {
+            return;
+        }
+
+        if (!(entityEvent.getEntity() instanceof Player player)) {
             return;
         }
 
@@ -142,15 +181,34 @@ public class KnockbackRegionController implements Listener {
             return;
         }
 
-        if (!this.regionProvider.isInRegion(event.getMount().getLocation())) {
+        Entity mount = this.getMount(event);
+        if (mount == null || !this.regionProvider.isInRegion(mount.getLocation())) {
             return;
         }
 
-        event.setCancelled(true);
+        if (event instanceof Cancellable cancellable) {
+            cancellable.setCancelled(true);
+        }
+
         this.noticeService.create()
             .player(player.getUniqueId())
             .notice(config -> config.messagesSettings.cantEnterOnRegion)
             .send();
+    }
+
+    private Entity getMount(Event event) {
+        try {
+            Method getMount = event.getClass().getMethod("getMount");
+            Object mount = getMount.invoke(event);
+
+            if (mount instanceof Entity entity) {
+                return entity;
+            }
+
+            return null;
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException exception) {
+            throw new IllegalStateException("Cannot read mount from " + event.getClass().getName(), exception);
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/updater/UpdaterNotificationController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/updater/UpdaterNotificationController.java
@@ -2,6 +2,8 @@ package com.eternalcode.combat.updater;
 
 import com.eternalcode.combat.config.implementation.PluginConfig;
 import com.eternalcode.commons.concurrent.FutureHandler;
+import com.eternalcode.commons.scheduler.Scheduler;
+import java.time.Duration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -15,11 +17,13 @@ public class UpdaterNotificationController implements Listener {
     private final UpdaterService updaterService;
     private final PluginConfig pluginConfig;
     private final MiniMessage miniMessage;
+    private final Scheduler scheduler;
 
-    public UpdaterNotificationController(UpdaterService updaterService, PluginConfig pluginConfig, MiniMessage miniMessage) {
+    public UpdaterNotificationController(UpdaterService updaterService, PluginConfig pluginConfig, MiniMessage miniMessage, Scheduler scheduler) {
         this.updaterService = updaterService;
         this.pluginConfig = pluginConfig;
         this.miniMessage = miniMessage;
+        this.scheduler = scheduler;
     }
 
     @EventHandler
@@ -33,7 +37,11 @@ public class UpdaterNotificationController implements Listener {
         this.updaterService.checkForUpdate()
             .thenAccept(result -> {
                 if (result.isUpdateAvailable()) {
-                    player.sendMessage(this.miniMessage.deserialize(NEW_VERSION_AVAILABLE));
+                    this.scheduler.runLater(() -> {
+                        if (player.isOnline()) {
+                            player.sendMessage(this.miniMessage.deserialize(NEW_VERSION_AVAILABLE));
+                        }
+                    }, Duration.ZERO);
                 }
             })
             .exceptionally(FutureHandler::handleException);


### PR DESCRIPTION
## Summary

Fixes several combat runtime and logic issues found during review:

- registers entity mount handling dynamically across Bukkit/Spigot event package variants so listener registration does not fail when one class is missing
- removes duplicate `PlaceBlockBlocker` registration
- moves update notifications and death flare particles back through the scheduler before touching Bukkit/player state
- updates border trigger indexing on the scheduler thread and stores indexes in a concurrent map
- fixes percent-based and player-health-based drop calculations so configured drop percentages match actual drops and XP
- applies `headDropOnlyInCombat` before head-drop chance rolls
- drops leftover kept items on respawn instead of silently losing them when inventory is full
- avoids cancelling firework damage at `MONITOR` priority

## Root Cause

The plugin mixed API-version-specific event classes, async callbacks, and Bukkit state access in several listener paths. A few drop calculations also treated the percentage to drop as the percentage to keep/remove.

## Validation

- `:eternalcombat-plugin:compileJava`
- `gradle check`

Note: the project currently has no test sources, so Gradle reports `test NO-SOURCE`.