### PR TITLE
GH-406 fix: audit findings

### DIFF
--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/CombatPlugin.java
@@ -208,8 +208,7 @@ public final class CombatPlugin extends JavaPlugin implements EternalCombatApi {
             new CommandsBlocker(this.fightManager, noticeService, pluginConfig),
             new ElytraBlocker(this.fightManager, pluginConfig),
             new ElytraEquipBlocker(this.fightManager, noticeService, pluginConfig, server),
-            new FlyingBlocker(this.fightManager, pluginConfig, server),
-            new PlaceBlockBlocker(this.fightManager, noticeService, pluginConfig)
+            new FlyingBlocker(this.fightManager, pluginConfig, server)
         );
 
         new KnockbackMountController(noticeService, this.regionProvider, this.fightManager).register(this);

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightManagerImpl.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightManagerImpl.java
@@ -27,13 +27,9 @@ public class FightManagerImpl implements FightManager {
 
     @Override
     public boolean isInCombat(UUID player) {
-        if (!this.fights.containsKey(player)) {
-            return false;
-        }
-
         FightTag fightTag = this.fights.get(player);
 
-        return !fightTag.isExpired();
+        return fightTag != null && !fightTag.isExpired();
     }
 
     @Override

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
@@ -89,6 +89,8 @@ public class FightTagCommand {
             return;
         }
 
+        boolean firstAlreadyInCombat = this.fightManager.isInCombat(firstTarget.getUniqueId());
+
         FightTagEvent firstTagEvent = this.fightManager.tag(firstTarget.getUniqueId(), combatTime, CauseOfTag.COMMAND);
 
         if (firstTagEvent.isCancelled()) {
@@ -104,8 +106,11 @@ public class FightTagCommand {
         if (secondTagEvent.isCancelled()) {
             CancelTagReason cancelReason = secondTagEvent.getCancelReason();
 
-            // Roll back the first tag so we do not leave only one player tagged.
-            this.fightManager.untag(firstTarget.getUniqueId(), CauseOfUnTag.COMMAND);
+            // Only roll back the first tag when this command actually created it;
+            // never untag a player who was already in combat beforehand.
+            if (!firstAlreadyInCombat) {
+                this.fightManager.untag(firstTarget.getUniqueId(), CauseOfUnTag.COMMAND);
+            }
 
             this.tagoutReasonHandler(sender, cancelReason, messagesSettings);
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTagCommand.java
@@ -90,7 +90,6 @@ public class FightTagCommand {
         }
 
         FightTagEvent firstTagEvent = this.fightManager.tag(firstTarget.getUniqueId(), combatTime, CauseOfTag.COMMAND);
-        FightTagEvent secondTagEvent = this.fightManager.tag(secondTarget.getUniqueId(), combatTime, CauseOfTag.COMMAND);
 
         if (firstTagEvent.isCancelled()) {
             CancelTagReason cancelReason = firstTagEvent.getCancelReason();
@@ -100,15 +99,16 @@ public class FightTagCommand {
             return;
         }
 
+        FightTagEvent secondTagEvent = this.fightManager.tag(secondTarget.getUniqueId(), combatTime, CauseOfTag.COMMAND);
+
         if (secondTagEvent.isCancelled()) {
             CancelTagReason cancelReason = secondTagEvent.getCancelReason();
 
+            // Roll back the first tag so we do not leave only one player tagged.
+            this.fightManager.untag(firstTarget.getUniqueId(), CauseOfUnTag.COMMAND);
+
             this.tagoutReasonHandler(sender, cancelReason, messagesSettings);
 
-            return;
-        }
-
-        if (firstTagEvent.isCancelled() && secondTagEvent.isCancelled()) {
             return;
         }
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTask.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/FightTask.java
@@ -38,7 +38,7 @@ public class FightTask implements Runnable {
 
             if (fightTag.isExpired()) {
                 this.fightManager.untag(playerUniqueId, CauseOfUnTag.TIME_EXPIRED);
-                return;
+                continue;
             }
 
             Duration remaining = fightTag.getRemainingDuration();

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/blocker/CommandsBlocker.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/blocker/CommandsBlocker.java
@@ -32,7 +32,7 @@ public class CommandsBlocker implements Listener {
             return;
         }
 
-        String command = event.getMessage().substring(1);
+        String command = normalizeCommand(event.getMessage().substring(1));
 
         boolean isAnyMatch = this.config.commands.restrictedCommands.stream()
             .anyMatch(restrictedCommand -> StringUtil.startsWithIgnoreCase(command, restrictedCommand));
@@ -49,6 +49,23 @@ public class CommandsBlocker implements Listener {
                 .send();
 
         }
+    }
+
+    // Trim leading spaces and strip any namespace prefix (e.g. "minecraft:tp" -> "tp")
+    // from the command label so blacklisted commands cannot be bypassed with those forms.
+    private static String normalizeCommand(String rawCommand) {
+        String command = rawCommand.stripLeading();
+
+        int spaceIndex = command.indexOf(' ');
+        String label = spaceIndex == -1 ? command : command.substring(0, spaceIndex);
+
+        int colonIndex = label.indexOf(':');
+        if (colonIndex == -1) {
+            return command;
+        }
+
+        String rest = spaceIndex == -1 ? "" : command.substring(spaceIndex);
+        return label.substring(colonIndex + 1) + rest;
     }
 
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/blocker/CommandsBlocker.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/blocker/CommandsBlocker.java
@@ -32,10 +32,12 @@ public class CommandsBlocker implements Listener {
             return;
         }
 
-        String command = normalizeCommand(event.getMessage().substring(1));
+        String original = event.getMessage().substring(1).stripLeading();
+        String command = normalizeCommand(original);
 
         boolean isAnyMatch = this.config.commands.restrictedCommands.stream()
-            .anyMatch(restrictedCommand -> StringUtil.startsWithIgnoreCase(command, restrictedCommand));
+            .anyMatch(restrictedCommand -> StringUtil.startsWithIgnoreCase(original, restrictedCommand)
+                || StringUtil.startsWithIgnoreCase(command, restrictedCommand));
 
         WhitelistBlacklistMode mode = this.config.commands.commandRestrictionMode;
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/death/DeathFlareController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/death/DeathFlareController.java
@@ -102,7 +102,7 @@ public class DeathFlareController implements Listener {
     }
 
     private void scheduleParticles(Firework flare, World world) {
-        this.scheduler.runLaterAsync(
+        this.scheduler.runLater(
             () -> {
                 if (flare.isDead() || !flare.isValid()) {
                     return;

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
@@ -4,6 +4,7 @@ import com.eternalcode.combat.event.DynamicListener;
 import com.eternalcode.combat.fight.FightManager;
 import com.eternalcode.commons.adventure.AdventureUtil;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -140,9 +141,13 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
             ItemStack[] itemsToGive = this.keepInventoryManager.nextItems(playerUniqueId)
                 .toArray(new ItemStack[0]);
 
+            // The player is not teleported yet during PlayerRespawnEvent, so
+            // player.getLocation() would still be the death location.
+            Location respawnLocation = event.getRespawnLocation();
+
             Map<Integer, ItemStack> leftover = playerInventory.addItem(itemsToGive);
             leftover.values().forEach(item ->
-                player.getWorld().dropItemNaturally(player.getLocation(), item));
+                respawnLocation.getWorld().dropItemNaturally(respawnLocation, item));
         }
     }
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
@@ -85,8 +85,8 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
             return false;
         }
 
-        if (this.dropSettings.headDropOnlyInCombat && inCombat) {
-            return true;
+        if (this.dropSettings.headDropOnlyInCombat && !inCombat) {
+            return false;
         }
 
         if (this.dropSettings.headDropChance <= 0.0) {

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/drop/DropController.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -139,7 +140,9 @@ public class DropController implements DynamicListener<PlayerDeathEvent> {
             ItemStack[] itemsToGive = this.keepInventoryManager.nextItems(playerUniqueId)
                 .toArray(new ItemStack[0]);
 
-            playerInventory.addItem(itemsToGive);
+            Map<Integer, ItemStack> leftover = playerInventory.addItem(itemsToGive);
+            leftover.values().forEach(item ->
+                player.getWorld().dropItemNaturally(player.getLocation(), item));
         }
     }
 }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/knockback/KnockbackRegionController.java
@@ -135,7 +135,7 @@ public class KnockbackRegionController implements Listener {
     void onTag(FightTagEvent event) {
         Player player = this.server.getPlayer(event.getPlayer());
         if (player == null) {
-            throw new IllegalStateException("Player cannot be null!");
+            return;
         }
 
         Optional<Region> regionOptional = this.regionProvider.getRegion(player.getLocation());

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/pearl/PearlServiceImpl.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/pearl/PearlServiceImpl.java
@@ -59,7 +59,7 @@ public class PearlServiceImpl implements PearlService {
                 this.scheduler.runLater(
                     () -> player.setCooldown(
                         Material.ENDER_PEARL,
-                        (int) this.pluginConfig.pearl.pearlThrowDelay.toMillis() / 50
+                        (int) (this.pluginConfig.pearl.pearlThrowDelay.toMillis() / 50)
                     ), Duration.ofMillis(50)
                 );
 

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/tagout/FightTagOutServiceImpl.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/tagout/FightTagOutServiceImpl.java
@@ -1,14 +1,34 @@
 package com.eternalcode.combat.fight.tagout;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 public class FightTagOutServiceImpl implements FightTagOutService {
 
-    private final Map<UUID, Instant> tagOuts = new HashMap<>();
+    // Self-expiring cache so entries are evicted at their end time instead of
+    // accumulating for every player that has ever tagged out.
+    private final Cache<UUID, Instant> tagOuts = Caffeine.newBuilder()
+        .expireAfter(new Expiry<UUID, Instant>() {
+            @Override
+            public long expireAfterCreate(UUID key, Instant endTime, long currentTime) {
+                return Math.max(0, Duration.between(Instant.now(), endTime).toNanos());
+            }
+
+            @Override
+            public long expireAfterUpdate(UUID key, Instant endTime, long currentTime, long currentDuration) {
+                return this.expireAfterCreate(key, endTime, currentTime);
+            }
+
+            @Override
+            public long expireAfterRead(UUID key, Instant endTime, long currentTime, long currentDuration) {
+                return currentDuration;
+            }
+        })
+        .build();
 
     @Override
     public void tagOut(UUID player, Duration duration) {
@@ -19,12 +39,12 @@ public class FightTagOutServiceImpl implements FightTagOutService {
 
     @Override
     public void unTagOut(UUID player) {
-        this.tagOuts.remove(player);
+        this.tagOuts.invalidate(player);
     }
 
     @Override
     public boolean isTaggedOut(UUID player) {
-        Instant endTime = this.tagOuts.get(player);
+        Instant endTime = this.tagOuts.getIfPresent(player);
 
         if (endTime == null) {
             return false;

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/trident/TridentController.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/fight/trident/TridentController.java
@@ -119,9 +119,15 @@ public class TridentController implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onUntag(FightUntagEvent event) {
-        Player player = server.getPlayer(event.getPlayer());
+        UUID playerId = event.getPlayer();
+        this.tridentService.removeDelay(playerId);
+
+        Player player = server.getPlayer(playerId);
+        if (player == null) {
+            return;
+        }
+
         player.setCooldown(Material.TRIDENT, 0);
-        this.tridentService.removeDelay(player.getUniqueId());
     }
 
     private boolean isRiptideInteract(PlayerInteractEvent event) {

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/util/InventoryUtil.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/util/InventoryUtil.java
@@ -24,23 +24,38 @@ public class InventoryUtil {
         List<ItemStack> currentItems = new ArrayList<>(list);
         List<ItemStack> removedItems = new ArrayList<>();
 
-        int currentItemsToDelete = itemsToDelete;
-        while (currentItemsToDelete > 0) {
-            int randomIndex = RANDOM.nextInt(list.size());
+        int totalAvailable = 0;
+        for (ItemStack item : currentItems) {
+            totalAvailable += Math.max(0, item.getAmount());
+        }
+
+        // Never try to remove more than is actually available, otherwise the loop
+        // could never reach zero and would spin forever.
+        int currentItemsToDelete = Math.min(itemsToDelete, totalAvailable);
+
+        while (currentItemsToDelete > 0 && !currentItems.isEmpty()) {
+            int randomIndex = RANDOM.nextInt(currentItems.size());
             ItemStack currentItem = currentItems.get(randomIndex);
 
             int amount = currentItem.getAmount();
-            int randomAmount = RANDOM.nextInt(0, Math.min(currentItemsToDelete, amount) + 1);
-
-            if (amount <= 0 || randomAmount <= 0) {
+            if (amount <= 0) {
+                currentItems.remove(randomIndex);
                 continue;
             }
+
+            int maxRemovable = Math.min(currentItemsToDelete, amount);
+            int randomAmount = RANDOM.nextInt(1, maxRemovable + 1);
 
             ItemStack removedItem = currentItem.clone();
             removedItem.setAmount(randomAmount);
             removedItems.add(removedItem);
 
-            currentItem.setAmount(amount - randomAmount);
+            int remaining = amount - randomAmount;
+            if (remaining <= 0) {
+                currentItems.remove(randomIndex);
+            } else {
+                currentItem.setAmount(remaining);
+            }
 
             currentItemsToDelete -= randomAmount;
         }

--- a/eternalcombat-plugin/src/main/java/com/eternalcode/combat/util/InventoryUtil.java
+++ b/eternalcombat-plugin/src/main/java/com/eternalcode/combat/util/InventoryUtil.java
@@ -26,7 +26,9 @@ public class InventoryUtil {
 
         int totalAvailable = 0;
         for (ItemStack item : currentItems) {
-            totalAvailable += Math.max(0, item.getAmount());
+            if (item != null) {
+                totalAvailable += Math.max(0, item.getAmount());
+            }
         }
 
         // Never try to remove more than is actually available, otherwise the loop
@@ -36,6 +38,12 @@ public class InventoryUtil {
         while (currentItemsToDelete > 0 && !currentItems.isEmpty()) {
             int randomIndex = RANDOM.nextInt(currentItems.size());
             ItemStack currentItem = currentItems.get(randomIndex);
+
+            // Bukkit inventory lists can contain null entries for empty slots.
+            if (currentItem == null) {
+                currentItems.remove(randomIndex);
+                continue;
+            }
 
             int amount = currentItem.getAmount();
             if (amount <= 0) {


### PR DESCRIPTION
I made Claude audit EternalCombat's codebase and it found a couple of findings. I will verify the claims and mark this PR as ready for review when I'm certain.

---

## Naprawione findingi

Każdy fix to osobny commit. Legenda: 🔴 wysoki · 🟠 średni · 🟡 niski.

| # | Waga | Plik | Problem | Naprawa |
|---|------|------|---------|---------|
| 1 | 🔴 | `CombatPlugin.java` | `PlaceBlockBlocker` zarejestrowany dwukrotnie — każde `BlockPlaceEvent` obsługiwane 2×, powiadomienie wysyłane 2× | Usunięto zduplikowaną rejestrację |
| 2 | 🔴 | `FightTask.java` | `return` zamiast `continue` — pierwszy wygasły tag przerywał cały tick, przy >1 graczu w walce powiadomienia gubiły się, a untag był opóźniony | `return` → `continue` |
| 3 | 🟠 | `DropController.java` | `headDropOnlyInCombat` nie egzekwowane — głowy wypadały poza walką, a w walce ignorowany był `headDropChance` | Blokada dropu poza walką, szansa zawsze respektowana |
| 4 | 🟠 | `TridentController.java` | NPE w `onUntag` — `server.getPlayer` zwraca `null` dla gracza offline (śmierć/wylogowanie) | Usuwanie delaya po UUID, cooldown tylko gdy online |
| 5 | 🟠 | `KnockbackRegionController.java` | `onTag` rzucał `IllegalStateException` dla offline gracza (crystal PvP) — stacktrace przy każdym takim tagu | `return` zamiast rzucania wyjątku |
| 6 | 🟠 | `DeathFlareController.java` | Dostęp do encji/świata z wątku async (`isDead`/`getLocation`/`spawnParticle`) — race na Paper, wyjątek na Folia | Przeniesiono pętlę cząsteczek na scheduler sync |
| 7 | 🟠 | `DropController.java` | Utrata przedmiotów przy respawnie — pozostałość z `addItem` ignorowana, pełny ekwipunek = zniszczone itemy | Nadmiar wyrzucany na ziemię |
| 8 | 🟡 | `InventoryUtil.java` | `removeRandomItems` — kruchy indeks, marnowane iteracje, ryzyko pętli przy misconfig, zerowe stacki w dropie | Indeks po kopii, clamp do dostępnej ilości, gwarancja postępu, usuwanie pustych stacków |
| 9 | 🟡 | `FightManagerImpl.java` | TOCTOU NPE w `isInCombat` — `containsKey` + `get` przy współbieżnym untagu (async PAPI/reload) | Pojedynczy `get` |
| 10 | 🟡 | `CommandsBlocker.java` | Obejście blokady komend przez namespace (`/minecraft:tp`) i wiodące spacje | Normalizacja labela: trim + strip namespace |
| 11 | 🟡 | `FightTagOutServiceImpl.java` | Nieograniczony wzrost `HashMap` — brak eksmisji wygasłych wpisów | Samo-wygasająca cache Caffeine z per-wpis TTL |
| — | minor | `PearlServiceImpl.java` | Precedencja rzutowania `(int)` przed dzieleniem — możliwy overflow dla dużych czasów | Dzielenie przed rzutowaniem |
| — | minor | `FightTagCommand.java` | `tagMultiple` — połowicznie nałożony tag przy anulowaniu drugiego + martwy kod | Drugi tag po sukcesie pierwszego, rollback przy anulowaniu |

### Nie ruszone (świadomie)
- **Riptide cooldown message** — powtarzalny komunikat to kwestia UX, nie bug.
- **`untagAll` nie odpala eventów** — dodanie ich uruchamiałoby side-effecty (reset trident/flight) per gracz; zmiana zamierzonego zachowania, zostawione do decyzji.

Moduł kompiluje się czysto (`compileJava`, `EXIT=0`) — tylko wcześniej istniejące ostrzeżenia deprecation.
